### PR TITLE
cleanup: build scripts inconsistencies.

### DIFF
--- a/ci/kokoro/docker/define-docker-variables.sh
+++ b/ci/kokoro/docker/define-docker-variables.sh
@@ -29,15 +29,28 @@ fi
 if [[ -n "${IMAGE+x}" ]]; then
   echo "IMAGE is already defined."
 else
-  if [[ -n "${DISTRO_VERSION+x}" ]]; then
-    readonly IMAGE_BASENAME="gcpp-common-ci-${DISTRO}-${DISTRO_VERSION}"
-    if [[ -n "${PROJECT_ID:-}" ]]; then
-      IMAGE="gcr.io/${PROJECT_ID}/google-cloud-cpp/${IMAGE_BASENAME}"
-    else
-      IMAGE="${IMAGE_BASENAME}"
-    fi
-    readonly IMAGE
-    readonly BUILD_OUTPUT="cmake-out/${IMAGE_BASENAME}-${BUILD_NAME}"
-    readonly BUILD_HOME="cmake-out/home/${IMAGE_BASENAME}-${BUILD_NAME}"
+  DOCKER_IMAGE_BASENAME="ci-${DISTRO}"
+  if [[ -n "${DISTRO_VERSION:-}" ]]; then
+    DOCKER_IMAGE_BASENAME="${DOCKER_IMAGE_BASENAME}-${DISTRO_VERSION}"
   fi
+  readonly DOCKER_IMAGE_BASENAME
+
+  if [[ -n "${PROJECT_ID:-}" ]]; then
+    DOCKER_IMAGE_PREFIX="gcr.io/${PROJECT_ID}/google-cloud-cpp-common"
+    IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_BASENAME}"
+  else
+    DOCKER_IMAGE_PREFIX="gcr.io/--no-project--/google-cloud-cpp-common"
+    IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_BASENAME}"
+  fi
+  readonly DOCKER_IMAGE_PREFIX
+  readonly IMAGE
+
+  BUILD_OUTPUT="cmake-out/${DOCKER_IMAGE_BASENAME}"
+  BUILD_HOME="cmake-out/home/${DOCKER_IMAGE_BASENAME}"
+  if [[ -n "${BUILD_NAME:-}" ]]; then
+    BUILD_OUTPUT="${BUILD_OUTPUT}-${BUILD_NAME}"
+    BUILD_HOME="${BUILD_HOME}-${BUILD_NAME}"
+  fi
+  readonly BUILD_OUTPUT
+  readonly BUILD_NAME
 fi

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -71,7 +71,7 @@ if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
 fi
 gcloud auth configure-docker
 
-readonly DEV_IMAGE="gcr.io/${PROJECT_ID}/google-cloud-cpp/test-install-${DISTRO}"
+readonly DEV_IMAGE="${DOCKER_IMAGE_PREFIX}/test-install-${DISTRO}"
 echo "================================================================"
 echo "Download existing image (if available) for ${DISTRO} $(date)."
 has_cache="false"
@@ -109,7 +109,8 @@ if docker build "${devtools_flags[@]}" ci; then
    update_cache="true"
 fi
 
-if "${update_cache}" && [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+if "${update_cache}" && [[ "${RUNNING_CI:-}" == "yes" ]] &&
+   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
   echo "================================================================"
   echo "Uploading updated base image for ${DISTRO} $(date)."
   # Do not stop the build on a failure to update the cache.

--- a/ci/kokoro/readme/build.sh
+++ b/ci/kokoro/readme/build.sh
@@ -71,7 +71,7 @@ if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
 fi
 gcloud auth configure-docker
 
-readonly DEV_IMAGE="gcr.io/${PROJECT_ID}/google-cloud-cpp/test-readme-${DISTRO}"
+readonly DEV_IMAGE="${DOCKER_IMAGE_PREFIX}/test-readme-${DISTRO}"
 echo "================================================================"
 echo "Download existing image (if available) for ${DISTRO} $(date)."
 has_cache="false"
@@ -109,7 +109,8 @@ if docker build "${devtools_flags[@]}" ci; then
    update_cache="true"
 fi
 
-if "${update_cache}" && [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+if "${update_cache}" && [[ "${RUNNING_CI:-}" == "yes" ]] &&
+   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
   echo "================================================================"
   echo "Uploading updated base image for ${DISTRO} $(date)."
   # Do not stop the build on a failure to update the cache.


### PR DESCRIPTION
Use more consistent naming for the docker images across the different
build types (install vs. readme vs. docker). Also use a folder (as
opposed to a name prefix) to separate the docker images for
google-cloud-cpp vs. google-cloud-cpp-common.
