### PR TITLE
bug: troubleshoot Windows builds

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -16,6 +16,9 @@
 # Stop on errors. This is similar to `set -e` on Unix shells.
 $ErrorActionPreference = "Stop"
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Capture Bazel information for troubleshooting"
+bazel version
+
 $common_flags = @()
 if (Test-Path env:RUNNING_CI) {
     # Create output directory for Bazel. Bazel creates really long paths,
@@ -23,7 +26,8 @@ if (Test-Path env:RUNNING_CI) {
     # root of the Bazel output directory works around this problem.
     $bazel_root="C:\b"
     if (-not (Test-Path $bazel_root)) {
-        New-Item -ItemType Directory -Path $bazel_root
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Create bazel user root (${bazel_root})"
+        New-Item -ItemType Directory -Path $bazel_root | Out-Null
     }
     $common_flags += ("--output_user_root=${bazel_root}")
 }
@@ -31,6 +35,8 @@ $test_flags = @("--test_output=errors",
                 "--verbose_failures=true",
                 "--keep_going")
 $build_flags = @("--keep_going")
+
+$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling and running unit tests"
 bazel $common_flags test $test_flags -- //google/cloud/...:all
@@ -43,3 +49,5 @@ bazel $common_flags build $build_flags -- //google/cloud/...:all
 if ($LastExitCode) {
     throw "bazel test failed with exit code $LastExitCode"
 }
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DONE"

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -18,8 +18,14 @@ $ErrorActionPreference = "Stop"
 
 $common_flags = @()
 if (Test-Path env:RUNNING_CI) {
-    # In the Kokoro builds we need to pass this flag.
-    $common_flags += ("--output_user_root=C:\b")
+    # Create output directory for Bazel. Bazel creates really long paths,
+    # sometimes exceeding the Windows limits. Using a short name for the
+    # root of the Bazel output directory works around this problem.
+    $bazel_root="C:\b"
+    if (-not (Test-Path $bazel_root)) {
+        New-Item -ItemType Directory -Path $bazel_root
+    }
+    $common_flags += ("--output_user_root=${bazel_root}")
 }
 $test_flags = @("--test_output=errors",
                 "--verbose_failures=true",

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -49,6 +49,11 @@ if ($LastExitCode) {
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running unit tests $env:CONFIG"
 Set-Location cmake-out
+if (Test-Path env:RUNNING_CI) {
+    # On Kokoro we need to define %TEMP% or the tests do not have a valid directory for
+    # temporary files.
+    $env:TEMP="T:\tmp"
+}
 ctest --output-on-failure -C $env:CONFIG
 if ($LastExitCode) {
     throw "ctest failed with exit code $LastExitCode"

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -1,26 +1,22 @@
-REM Copyright 2018 Google LLC
-REM
-REM Licensed under the Apache License, Version 2.0 (the "License");
-REM you may not use this file except in compliance with the License.
-REM You may obtain a copy of the License at
-REM
-REM     http://www.apache.org/licenses/LICENSE-2.0
-REM
-REM Unless required by applicable law or agreed to in writing, software
-REM distributed under the License is distributed on an "AS IS" BASIS,
-REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-REM See the License for the specific language governing permissions and
-REM limitations under the License.
+@REM Copyright 2018 Google LLC
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
 
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-REM Set TEMP explicitly for windows 2019 image
-set TEMP = "T:\tmp\"
-
+REM The remaining of the build script is implemented in PowerShell.
 echo %date% %time%
 cd github\google-cloud-cpp-common
-
-echo %date% %time%
 powershell -exec bypass ci\kokoro\windows\build.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -71,17 +71,6 @@ powershell -exec bypass "${ScriptLocation}/${BuildScript}"
 # even if the build fails.
 $BuildExitCode = $LastExitCode
 
-if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
-    # Kokoro rsyncs all the files in the %KOKORO_ARTIFACTS_DIR%, which takes a
-    # long time. The recommended workaround is to remove all the files that are
-    # not interesting artifacts.
-    Write-Host
-    Get-Date -Format o
-    Write-Host "Cleaning up artifacts... "
-    Set-Location $env:KOKORO_ARTIFACTS_DIR
-    Get-ChildItem -Recurse -File -Exclude "test.xml,sponge_log.xml,build.bat" | Remove-Item -Recurse -Force
-}
-
 if ($BuildExitCode) {
     throw "Build failed with exit code $LastExitCode"
 }

--- a/ci/kokoro/windows/cmake-presubmit.cfg
+++ b/ci/kokoro/windows/cmake-presubmit.cfg
@@ -17,3 +17,5 @@ env_vars {
   key: "BUILD_CACHE"
   value: "gs://cloud-cpp-kokoro-results/build-artifacts/common/windows/cmake-vcpkg-installed.zip"
 }
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/windows/cmake.cfg
+++ b/ci/kokoro/windows/cmake.cfg
@@ -17,3 +17,5 @@ env_vars {
   key: "BUILD_CACHE"
   value: "gs://cloud-cpp-kokoro-results/build-artifacts/common/windows/cmake-vcpkg-installed.zip"
 }
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"


### PR DESCRIPTION
Fixed several bugs in the download of the vcpkg cache. Also setting
the `TEMP` environment variable to non-whitelisted values disables
functionality in PowerShell used by vcpkg. We need to keep the
default value until just before running the unit tests, at which
point the default does not work, sigh.

For the Bazel build we needed to set `BAZEL_VC` to the right location,
Bazel does not seem able to automatically detect MSVC 2019.

