### PR TITLE
ci: upgrade builds to use Bazel 1.0

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -19,7 +19,7 @@ set -eu
 readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
   |  tr '[:upper:]' '[:lower:]')
 
-readonly BAZEL_VERSION="0.24.0"
+readonly BAZEL_VERSION="1.0.0"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"


### PR DESCRIPTION
Now that Bazel reached 1.0 and it is expected to follow semver, it seems
better to test with that version. The downside is that we may not notice
breakage for users in the 0.24.0-0.29.0 range. But it seems that Bazel
users are rapidly moving towards using 1.0 anyway.
