### PR TITLE
cleanup: tell Bazel to ignore build directories

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+ci/
+cmake-out/
+cmake-build-*/


### PR DESCRIPTION
For folks that like to type `bazel build ...` we need to instruct Bazel
to ignore the build directories. These may contain test BUILD files that
are only usable in a Docker image or otherwise not usable from the
top-level directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/48)
<!-- Reviewable:end -->
