### PR TITLE
feat: implement std::apply

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -162,6 +162,8 @@ add_library(google_cloud_cpp_common
             internal/setenv.h
             internal/throw_delegate.cc
             internal/throw_delegate.h
+            internal/tuple.h
+            internal/utility.h
             internal/version_info.h
             log.cc
             log.h
@@ -222,6 +224,8 @@ if (BUILD_TESTING)
         internal/random_test.cc
         internal/retry_policy_test.cc
         internal/throw_delegate_test.cc
+        internal/tuple_test.cc
+        internal/utility_test.cc
         internal/env_test.cc
         log_test.cc
         optional_test.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -46,6 +46,8 @@ google_cloud_cpp_common_hdrs = [
     "internal/retry_policy.h",
     "internal/setenv.h",
     "internal/throw_delegate.h",
+    "internal/tuple.h",
+    "internal/utility.h",
     "internal/version_info.h",
     "log.h",
     "optional.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -33,6 +33,8 @@ google_cloud_cpp_common_unit_tests = [
     "internal/random_test.cc",
     "internal/retry_policy_test.cc",
     "internal/throw_delegate_test.cc",
+    "internal/tuple_test.cc",
+    "internal/utility_test.cc",
     "internal/env_test.cc",
     "log_test.cc",
     "optional_test.cc",

--- a/google/cloud/internal/tuple.h
+++ b/google/cloud/internal/tuple.h
@@ -1,0 +1,76 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TUPLE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TUPLE_H_
+
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/utility.h"
+#include "google/cloud/version.h"
+#include <tuple>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+// This header reimplements some of C++14's <tuple> header.
+
+namespace detail {
+
+/**
+ * Extract the return type of `std::apply` for given argument types.
+ */
+template <typename F, typename Tuple>
+struct ApplyRes {};
+
+/**
+ * Extract the return type of `std::apply` for given argument types.
+ */
+template <typename F, typename... Args>
+struct ApplyRes<F, std::tuple<Args...>> {
+  using type = typename invoke_result<F, Args...>::type;
+};
+
+/**
+ * Implementation of `apply`.
+ *
+ * Inspired by the exampe in section 20.5.1 of the standard.
+ *
+ * @tparam F the functor to apply the tuple to
+ * @tparam Tuple the tuple of arguments to apply to `F`
+ * @tparam I indices 0..(sizeof(Tuple)-1)
+ */
+template <class F, class Tuple, std::size_t... I>
+typename detail::ApplyRes<F, Tuple>::type ApplyImpl(F&& f, Tuple&& t,
+                                                    index_sequence<I...>) {
+  return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
+}
+
+}  // namespace detail
+
+// Reimplementation of `std::apply` from C++14
+template <class F, class Tuple>
+typename detail::ApplyRes<F, Tuple>::type apply(F&& f, Tuple&& t) {
+  using Indices = make_index_sequence<std::tuple_size<Tuple>::value>;
+  return detail::ApplyImpl(std::forward<F>(f), std::forward<Tuple>(t),
+                           Indices());
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TUPLE_H_

--- a/google/cloud/internal/tuple.h
+++ b/google/cloud/internal/tuple.h
@@ -27,8 +27,6 @@ namespace internal {
 
 // This header reimplements some of C++14's <tuple> header.
 
-namespace detail {
-
 /**
  * Extract the return type of `std::apply` for given argument types.
  */
@@ -53,19 +51,16 @@ struct ApplyRes<F, std::tuple<Args...>> {
  * @tparam I indices 0..(sizeof(Tuple)-1)
  */
 template <class F, class Tuple, std::size_t... I>
-typename detail::ApplyRes<F, Tuple>::type ApplyImpl(F&& f, Tuple&& t,
-                                                    index_sequence<I...>) {
+typename ApplyRes<F, Tuple>::type ApplyImpl(F&& f, Tuple&& t,
+                                            index_sequence<I...>) {
   return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
 }
 
-}  // namespace detail
-
 // Reimplementation of `std::apply` from C++14
 template <class F, class Tuple>
-typename detail::ApplyRes<F, Tuple>::type apply(F&& f, Tuple&& t) {
+typename ApplyRes<F, Tuple>::type apply(F&& f, Tuple&& t) {
   using Indices = make_index_sequence<std::tuple_size<Tuple>::value>;
-  return detail::ApplyImpl(std::forward<F>(f), std::forward<Tuple>(t),
-                           Indices());
+  return ApplyImpl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
 }
 
 }  // namespace internal

--- a/google/cloud/internal/tuple_test.cc
+++ b/google/cloud/internal/tuple_test.cc
@@ -1,0 +1,63 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/tuple.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+TEST(ApplyTest, Simple) {
+  std::string s;
+  int i;
+  char c;
+  auto res = ::google::cloud::internal::apply(
+      [&](std::string new_s, int new_i, char new_c) {
+        s = std::move(new_s);
+        i = new_i;
+        c = new_c;
+        return i * 2;
+      },
+      std::make_tuple("hello world", 42, 'x'));
+  static_assert(std::is_same<decltype(res), int>::value, "");
+  EXPECT_EQ("hello world", s);
+  EXPECT_EQ(42, i);
+  EXPECT_EQ('x', c);
+  EXPECT_EQ(84, res);
+}
+
+TEST(ApplyTest, VoidResult) {
+  int i;
+  auto f = [&](int new_i) { i = new_i; };
+  static_assert(
+      std::is_same<void,
+                   invoke_result_t<decltype(::google::cloud::internal::apply<
+                                            decltype(f), std::tuple<int>>),
+                                   decltype(f), std::tuple<int>>>::value,
+      "");
+  ::google::cloud::internal::apply(f, std::make_tuple(42));
+  EXPECT_EQ(42, i);
+}
+
+TEST(ApplyTest, NoArgs) {
+  int i = ::google::cloud::internal::apply([] { return 42; }, std::tuple<>());
+  EXPECT_EQ(42, i);
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/utility.h
+++ b/google/cloud/internal/utility.h
@@ -1,0 +1,101 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_UTILITY_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_UTILITY_H_
+
+#include "google/cloud/version.h"
+#include <type_traits>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+// This header reimplements some of C++14's <utlity> header.
+
+// Reimplementation of C++14 `std::integer_sequence`.
+template <class T, T... I>
+struct integer_sequence {
+  typedef T value_type;
+  static constexpr size_t size() noexcept { return sizeof...(I); }
+};
+
+// Reimplementation of C++14 `std::index_sequence`.
+template <std::size_t... Ints>
+using index_sequence = integer_sequence<std::size_t, Ints...>;
+
+namespace detail {
+
+/**
+ * Implementation of `make_index_sequence`.
+ *
+ * `make_index_sequence_impl` references itself accumulating the result
+ * indices in `I`. The recursion stops when `N` reaches 0. By that time, `I`
+ * should contain the result.
+ *
+ * `make_index_sequence_impl<T, N, void, I...>::result` will return an
+ * `integer_sequence<T, 0, 1, 2, ..., (N - 1), I...>`.
+ *
+ * @tparam T the type of the index in `index_sequence`
+ * @tparam N the counter bounding type recursion; `std::integral_constant` has
+ *     to be used because spacializing a template with a value of type which is
+ *     dependent on a different template parameter is not allowed.
+ * @tparam Enable ignored, formal parameter to allow for disabling some
+ *     specializations
+ * @tparam `I` indices accumulated so far in the recursion.
+ */
+template <typename T, typename N, typename Enable, T... I>
+struct make_index_sequence_impl {};
+
+/**
+ * Implementation od `make_index_sequence`.
+ *
+ * Specialization for N > 0.
+ */
+template <typename T, T N, T... I>
+struct make_index_sequence_impl<T, std::integral_constant<T, N>,
+                                typename std::enable_if<(N > 0), void>::type,
+                                I...> {
+  using result =
+      typename make_index_sequence_impl<T, std::integral_constant<T, N - 1>,
+                                        void, N - 1, I...>::result;
+};
+
+/**
+ * Implementation od `make_index_sequence`.
+ *
+ * Specialization for N == 0.
+ */
+template <typename T, T... I>
+struct make_index_sequence_impl<T, std::integral_constant<T, 0>, void, I...> {
+  using result = integer_sequence<T, I...>;
+};
+
+}  // namespace detail
+
+template <class T, T N>
+using make_integer_sequence =
+    typename detail::make_index_sequence_impl<T, std::integral_constant<T, N>,
+                                              void>::result;
+
+template <size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_UTILITY_H_

--- a/google/cloud/internal/utility.h
+++ b/google/cloud/internal/utility.h
@@ -36,16 +36,14 @@ struct integer_sequence {
 template <std::size_t... Ints>
 using index_sequence = integer_sequence<std::size_t, Ints...>;
 
-namespace detail {
-
 /**
  * Implementation of `make_index_sequence`.
  *
- * `make_index_sequence_impl` references itself accumulating the result
+ * `MakeIndexSequenceImpl` references itself accumulating the result
  * indices in `I`. The recursion stops when `N` reaches 0. By that time, `I`
  * should contain the result.
  *
- * `make_index_sequence_impl<T, N, void, I...>::result` will return an
+ * `MakeIndexSequenceImpl<T, N, void, I...>::result` will return an
  * `integer_sequence<T, 0, 1, 2, ..., (N - 1), I...>`.
  *
  * @tparam T the type of the index in `index_sequence`
@@ -57,38 +55,36 @@ namespace detail {
  * @tparam `I` indices accumulated so far in the recursion.
  */
 template <typename T, typename N, typename Enable, T... I>
-struct make_index_sequence_impl {};
+struct MakeIndexSequenceImpl {};
 
 /**
- * Implementation od `make_index_sequence`.
+ * Implementation of `make_index_sequence`.
  *
  * Specialization for N > 0.
  */
 template <typename T, T N, T... I>
-struct make_index_sequence_impl<T, std::integral_constant<T, N>,
-                                typename std::enable_if<(N > 0), void>::type,
-                                I...> {
+struct MakeIndexSequenceImpl<T, std::integral_constant<T, N>,
+                             typename std::enable_if<(N > 0), void>::type,
+                             I...> {
   using result =
-      typename make_index_sequence_impl<T, std::integral_constant<T, N - 1>,
-                                        void, N - 1, I...>::result;
+      typename MakeIndexSequenceImpl<T, std::integral_constant<T, N - 1>, void,
+                                     N - 1, I...>::result;
 };
 
 /**
- * Implementation od `make_index_sequence`.
+ * Implementation of `make_index_sequence`.
  *
  * Specialization for N == 0.
  */
 template <typename T, T... I>
-struct make_index_sequence_impl<T, std::integral_constant<T, 0>, void, I...> {
+struct MakeIndexSequenceImpl<T, std::integral_constant<T, 0>, void, I...> {
   using result = integer_sequence<T, I...>;
 };
 
-}  // namespace detail
-
 template <class T, T N>
 using make_integer_sequence =
-    typename detail::make_index_sequence_impl<T, std::integral_constant<T, N>,
-                                              void>::result;
+    typename MakeIndexSequenceImpl<T, std::integral_constant<T, N>,
+                                   void>::result;
 
 template <size_t N>
 using make_index_sequence = make_integer_sequence<size_t, N>;

--- a/google/cloud/internal/utility_test.cc
+++ b/google/cloud/internal/utility_test.cc
@@ -1,0 +1,41 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/utility.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+TEST(MakeIndexSequence, Simple) {
+  static_assert(std::is_same<integer_sequence<std::size_t>,
+                             make_index_sequence<0>>::value,
+                "");
+  static_assert(std::is_same<integer_sequence<std::size_t, 0, 1, 2, 3, 4>,
+                             make_index_sequence<5>>::value,
+                "");
+  static_assert(
+      std::is_same<integer_sequence<int>, make_integer_sequence<int, 0>>::value,
+      "");
+  static_assert(std::is_same<integer_sequence<int, 0, 1, 2, 3, 4>,
+                             make_integer_sequence<int, 5>>::value,
+                "");
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This is a part of googleapis/google-cloud-cpp#3016.

Composing GCS objects consists of multiple operations under the hood.
Different subsets of the options passed to the recursive compose
operation have to be passed on to the underlying operations.

By GCS C++ client convention, options are passed as parameter packs,
hence in the general case the filtering has to be done in compile time.

An easy way to filter these parameters is to pack them in a
`std::tuple`, process the tuple and apply it via `std::apply`.
Unfortunately, `std::apply` is only available in C++14, so this PR
reimplements it in a API-compatible way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/59)
<!-- Reviewable:end -->
