### PR TITLE
ci: fix the kokoro readme builds configuration

### DIFF
--- a/ci/kokoro/readme/common.cfg
+++ b/ci/kokoro/readme/common.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "google-cloud-cpp-common/ci/kokoro/install/build.sh"
+build_file: "google-cloud-cpp-common/ci/kokoro/readme/build.sh"
 timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-service-account.json"


### PR DESCRIPTION
The builds were actually duplicating the work in the install builds and
not checking the README instructions. Unfortunately the builds
"worked", but failed to detect the openSUSE:Tumbleweed problems.

Part of the work for #56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/60)
<!-- Reviewable:end -->
