### PR TITLE
ci: refactor definition of docker image names

### DIFF
--- a/ci/kokoro/define-docker-variables.sh
+++ b/ci/kokoro/define-docker-variables.sh
@@ -30,22 +30,32 @@ if [[ -n "${IMAGE+x}" ]]; then
   echo "IMAGE is already defined."
 else
   DOCKER_IMAGE_BASENAME="ci-${DISTRO}"
+  DOCKER_README_IMAGE_BASENAME="ci-readme-${DISTRO}"
+  DOCKER_INSTALL_IMAGE_BASENAME="ci-install-${DISTRO}"
   if [[ -n "${DISTRO_VERSION:-}" ]]; then
     DOCKER_IMAGE_BASENAME="${DOCKER_IMAGE_BASENAME}-${DISTRO_VERSION}"
+    DOCKER_README_IMAGE_BASENAME="${DOCKER_README_IMAGE_BASENAME}-${DISTRO_VERSION}"
+    DOCKER_INSTALL_IMAGE_BASENAME="${DOCKER_INSTALL_IMAGE_BASENAME}-${DISTRO_VERSION}"
   fi
+  readonly DOCKER_README_IMAGE_BASENAME
+  readonly DOCKER_INSTALL_IMAGE_BASENAME
   readonly DOCKER_IMAGE_BASENAME
 
   if [[ -n "${PROJECT_ID:-}" ]]; then
     DOCKER_IMAGE_PREFIX="gcr.io/${PROJECT_ID}/google-cloud-cpp-common"
-    IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_BASENAME}"
   else
     # We want a prefix that works when running interactively, so it must be a
     # (syntactically) valid project id, this works.
     DOCKER_IMAGE_PREFIX="gcr.io/cloud-cpp-reserved/google-cloud-cpp-common"
-    IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_BASENAME}"
   fi
   readonly DOCKER_IMAGE_PREFIX
+
+  IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_BASENAME}"
+  README_IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_README_IMAGE_BASENAME}"
+  INSTALL_IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_INSTALL_IMAGE_BASENAME}"
   readonly IMAGE
+  readonly README_IMAGE
+  readonly README_INSTALL_IMAGE
 
   BUILD_OUTPUT="cmake-out/${DOCKER_IMAGE_BASENAME}"
   BUILD_HOME="cmake-out/home/${DOCKER_IMAGE_BASENAME}"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -198,7 +198,7 @@ if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
   source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
 fi
 
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 
 echo "================================================================"

--- a/ci/kokoro/docker/dump-logs.sh
+++ b/ci/kokoro/docker/dump-logs.sh
@@ -19,7 +19,7 @@ set -eu
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 
 # Dump the emulator log file. Tests run in the google/cloud/bigtable/tests

--- a/ci/kokoro/docker/dump-reports.sh
+++ b/ci/kokoro/docker/dump-reports.sh
@@ -19,7 +19,7 @@ set -eu
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 
 # If w3m is installed there is nothing to do.
 if ! type w3m >/dev/null 2>&1; then

--- a/ci/kokoro/docker/publish-refdocs.sh
+++ b/ci/kokoro/docker/publish-refdocs.sh
@@ -46,7 +46,7 @@ fi
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 
 echo "================================================================"
 echo "Installing docuploader package $(date)."

--- a/ci/kokoro/docker/upload-coverage.sh
+++ b/ci/kokoro/docker/upload-coverage.sh
@@ -18,7 +18,7 @@ set -eu
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 
 if [[ "${BUILD_TYPE:-}" != "Coverage" ]]; then

--- a/ci/kokoro/docker/upload-docs.sh
+++ b/ci/kokoro/docker/upload-docs.sh
@@ -18,7 +18,7 @@ set -eu
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 
 # Exit successfully (and silently) if there are no documents to upload.

--- a/ci/kokoro/readme/build.sh
+++ b/ci/kokoro/readme/build.sh
@@ -47,7 +47,7 @@ fi
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 
 echo "================================================================"
 echo "Change working directory to project root $(date)."
@@ -71,7 +71,6 @@ if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
 fi
 gcloud auth configure-docker
 
-readonly README_IMAGE="${DOCKER_IMAGE_PREFIX}/test-readme-${DISTRO}"
 echo "================================================================"
 echo "Download existing image (if available) for ${DISTRO} $(date)."
 has_cache="false"

--- a/ci/templates/kokoro/readme/build.sh
+++ b/ci/templates/kokoro/readme/build.sh
@@ -47,7 +47,7 @@ fi
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 
 echo "================================================================"
 echo "Change working directory to project root $(date)."


### PR DESCRIPTION
Move the define-docker-variables.sh file to a location where it can be
shared across the builds that use docker
(ci/kokoro/{docker,image,readme}) and define all the image names in this
file.

This new location is already in use by other repositories, and will make
it easier to share (or generate) build scripts for all repositories in
its new location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/68)
<!-- Reviewable:end -->
