### PR TITLE
ci: scripts to generate ci/kokoro/install

### DIFF
--- a/ci/templates/generate-kokoro-install.sh
+++ b/ci/templates/generate-kokoro-install.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $(basename "$0") <destination-ci-directory>"
+  exit 1
+fi
+
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  PROJECT_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+  readonly PROJECT_ROOT
+fi
+
+DESTINATION_ROOT="$1"
+readonly DESTINATION_ROOT
+
+source "${DESTINATION_ROOT}/ci/etc/repo-config.sh"
+
+BUILD_NAMES=(
+  centos-7
+  centos-8
+  debian-buster
+  debian-stretch
+  fedora
+  opensuse-leap
+  opensuse-tumbleweed
+  ubuntu-trusty
+  ubuntu-xenial
+  ubuntu-bionic
+)
+readonly BUILD_NAMES
+
+set +e
+source "${PROJECT_ROOT}/ci/templates/kokoro/install/docker-fragments.sh"
+source "${DESTINATION_ROOT}/ci/etc/kokoro/install/project-config.sh"
+set -e
+
+generate_dockerfile() {
+  local -r build="$1"
+
+  target="${DESTINATION_ROOT}/ci/kokoro/install/Dockerfile.${build}"
+  echo "Generating ${target} "
+  # We cannot use simple shell expansion in the next fragment because the
+  # backticks (needed for formatting) are interpreted as "launch shell".
+  replace_fragments \
+        "INSTALL_PROTOBUF_FROM_SOURCE" \
+        "INSTALL_C_ARES_FROM_SOURCE" \
+        "INSTALL_GRPC_FROM_SOURCE" \
+        "INSTALL_CPP_CMAKEFILES_FROM_SOURCE" \
+        "INSTALL_GOOGLETEST_FROM_SOURCE" \
+        "INSTALL_CRC32C_FROM_SOURCE" \
+        "INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE" \
+        "BUILD_AND_TEST_PROJECT_FRAGMENT" \
+    <"${PROJECT_ROOT}/ci/templates/kokoro/install/Dockerfile.${build}.in" \
+    >"${target}"
+}
+
+# Remove all files, any files we want to preserve will be created again.
+git -C "${DESTINATION_ROOT}" rm -fr "ci/kokoro/install" || true
+
+mkdir -p "${DESTINATION_ROOT}/ci/kokoro/install"
+
+cp "${PROJECT_ROOT}/ci/templates/kokoro/install/build.sh" \
+   "${DESTINATION_ROOT}/ci/kokoro/install/build.sh"
+
+git -C "${DESTINATION_ROOT}" reset HEAD "ci/kokoro/install/common.cfg"
+git -C "${DESTINATION_ROOT}" checkout -- "ci/kokoro/install/common.cfg"
+
+for build in "${BUILD_NAMES[@]}"; do
+  touch "${DESTINATION_ROOT}/ci/kokoro/install/${build}.cfg"
+  touch "${DESTINATION_ROOT}/ci/kokoro/install/${build}-presubmit.cfg"
+  generate_dockerfile "${build}"
+done
+
+git -C "${DESTINATION_ROOT}" add "ci/kokoro/install"

--- a/ci/templates/kokoro/install/Dockerfile.centos-7.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-7.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=7
 FROM centos:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 
@@ -64,7 +63,7 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 # ```
 
-# Then we install it using using:
+# Then we install it using:
 
 # ```bash
 @INSTALL_GRPC_FROM_SOURCE@

--- a/ci/templates/kokoro/install/Dockerfile.centos-7.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-7.in
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=7
+FROM centos:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# First install the development tools and OpenSSL. The development tools
+# distributed with CentOS 7 (notably CMake) are too old to build
+# the project. In these instructions, we use `cmake3` obtained from
+# [Software Collections](https://www.softwarecollections.org/).
+
+# ```bash
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y centos-release-scl
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum makecache && \
+    yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
+        make openssl-devel pkgconfig tar wget which zlib-devel
+RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
+# ```
+
+# #### Protobuf
+
+# We need to install a version of Protobuf, recent enough that it supports the
+# Google Cloud Platform proto files:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### c-ares
+
+# Recent versions of gRPC require c-ares >= 1.11, while CentOS-7
+# distributes c-ares-1.10. Manually install a newer version:
+
+# ```bash
+@INSTALL_C_ARES_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# To install gRPC we first need to configure pkg-config to find the version of
+# Protobuf we just installed in `/usr/local`:
+
+# ```bash
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+# ```
+
+# Then we install it using using:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.centos-8.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-8.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=8
 FROM centos:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 
@@ -49,7 +48,7 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 # ```
 
-# Then we install it using using:
+# Then we install it using:
 
 # ```bash
 @INSTALL_GRPC_FROM_SOURCE@

--- a/ci/templates/kokoro/install/Dockerfile.centos-8.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-8.in
@@ -1,0 +1,58 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=8
+FROM centos:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools, libcurl, OpenSSL, and the c-ares
+# library (required by gRPC):
+
+# ```bash
+RUN dnf makecache && \
+    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+        zlib-devel libcurl-devel c-ares-devel tar wget which
+# ```
+
+# #### Protobuf
+
+# We need to install a version of Protobuf, recent enough that it supports the
+# Google Cloud Platform proto files:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# To install gRPC we first need to configure pkg-config to find the version of
+# Protobuf we just installed in `/usr/local`:
+
+# ```bash
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+# ```
+
+# Then we install it using using:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.debian-buster.in
+++ b/ci/templates/kokoro/install/Dockerfile.debian-buster.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=buster
 FROM debian:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 

--- a/ci/templates/kokoro/install/Dockerfile.debian-buster.in
+++ b/ci/templates/kokoro/install/Dockerfile.debian-buster.in
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=buster
+FROM debian:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools, libcurl, and OpenSSL:
+
+# ```bash
+RUN apt update && \
+    apt install -y build-essential cmake git gcc g++ cmake \
+        libcurl4-openssl-dev libssl-dev make pkg-config tar wget zlib1g-dev
+# ```
+
+# Debian 10 includes versions of gRPC and Protobuf that support the
+# Google Cloud Platform proto files. We simply install these pre-built versions:
+
+# ```bash
+RUN apt update && \
+    apt install -y libgrpc++-dev libprotobuf-dev \
+        protobuf-compiler protobuf-compiler-grpc
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
+++ b/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
@@ -1,0 +1,58 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=stretch
+FROM debian:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# First install the development tools and libcurl.
+# On Debian 9, libcurl links against openssl-1.0.2, and one must link
+# against the same version or risk an inconsistent configuration of the library.
+# This is especially important for multi-threaded applications, as openssl-1.0.2
+# requires explicitly setting locking callbacks. Therefore, to use libcurl one
+# must link against openssl-1.0.2. To do so, we need to install libssl1.0-dev.
+# Note that this removes libssl-dev if you have it installed already, and would
+# prevent you from compiling against openssl-1.1.0.
+
+# ```bash
+RUN apt update && \
+    apt install -y build-essential cmake git gcc g++ cmake \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make \
+        pkg-config tar wget zlib1g-dev
+# ```
+
+# #### Protobuf
+
+# We need to install a version of Protobuf, recent enough that it supports the
+# Google Cloud Platform proto files:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# To install gRPC we first need to configure pkg-config to find the version of
+# Protobuf we just installed in `/usr/local`:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
+++ b/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=stretch
 FROM debian:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 

--- a/ci/templates/kokoro/install/Dockerfile.fedora.in
+++ b/ci/templates/kokoro/install/Dockerfile.fedora.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=30
 FROM fedora:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 

--- a/ci/templates/kokoro/install/Dockerfile.fedora.in
+++ b/ci/templates/kokoro/install/Dockerfile.fedora.in
@@ -1,0 +1,42 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=30
+FROM fedora:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools:
+
+# ```bash
+RUN dnf makecache && \
+    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+        zlib-devel
+# ```
+
+# Fedora 30 includes packages for gRPC, libcurl, and OpenSSL that are recent
+# enough for the project. Install these packages and additional development
+# tools to compile the dependencies:
+
+# ```bash
+RUN dnf makecache && \
+    dnf install -y grpc-devel grpc-plugins \
+        libcurl-devel protobuf-compiler tar wget zlib-devel
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
+++ b/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
@@ -1,0 +1,70 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=latest
+FROM opensuse/leap:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools, libcurl and OpenSSL. The gRPC Makefile
+# uses `which` to determine whether the compiler is available. Install this
+# command for the extremely rare case where it may be missing from your
+# workstation or build server.
+
+# ```bash
+RUN zypper refresh && \
+    zypper install --allow-downgrade -y automake cmake gcc gcc-c++ git gzip \
+        libcurl-devel libopenssl-devel libtool make tar wget which
+# ```
+
+# #### Protobuf
+
+# We need to install a version of Protobuf, recent enough that it supports the
+# Google Cloud Platform proto files:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### c-ares
+
+# Recent versions of gRPC require c-ares >= 1.11, while openSUSE/Leap
+# distributes c-ares-1.9. Manually install a newer version:
+
+# ```bash
+@INSTALL_C_ARES_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files, first configure pkg-config to find the version of
+# Protobuf we just installed in `/usr/local`:
+
+# ```bash
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+# ```
+
+# The we install it using using:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
+++ b/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=latest
 FROM opensuse/leap:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 
@@ -61,7 +60,7 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 # ```
 
-# The we install it using using:
+# The we install it using:
 
 # ```bash
 @INSTALL_GRPC_FROM_SOURCE@

--- a/ci/templates/kokoro/install/Dockerfile.opensuse-tumbleweed.in
+++ b/ci/templates/kokoro/install/Dockerfile.opensuse-tumbleweed.in
@@ -1,0 +1,40 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=latest
+FROM opensuse/tumbleweed:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools, libcurl and OpenSSL:
+
+# ```bash
+RUN zypper refresh && \
+    zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+        libcurl-devel libopenssl-devel make tar wget zlib-devel
+# ```
+
+# The versions of gRPC and Protobuf packaged with openSUSE/Tumbleweed are recent
+# enough to support the Google Cloud Platform proto files.
+
+# ```bash
+RUN zypper refresh && \
+    zypper install -y grpc-devel
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.opensuse-tumbleweed.in
+++ b/ci/templates/kokoro/install/Dockerfile.opensuse-tumbleweed.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=latest
 FROM opensuse/tumbleweed:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
@@ -1,0 +1,51 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=bionic
+FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools, libcurl, OpenSSL and libc-ares:
+
+# ```bash
+RUN apt update && \
+    apt install -y build-essential cmake git gcc g++ cmake \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
+        pkg-config tar wget zlib1g-dev
+# ```
+
+# #### Protobuf
+
+# We need to install a version of Protobuf, recent enough that it supports the
+# Google Cloud Platform proto files:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We install it using using:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=bionic
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 
@@ -42,7 +41,7 @@ RUN apt update && \
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
-# Cloud Platform proto files. We install it using using:
+# Cloud Platform proto files. We install it using:
 
 # ```bash
 @INSTALL_GRPC_FROM_SOURCE@

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-trusty.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-trusty.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=trusty
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-trusty.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-trusty.in
@@ -1,0 +1,92 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=trusty
+FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools.
+# We use the `ubuntu-toolchain-r` PPA to get a modern version of CMake:
+
+# ```bash
+RUN apt update && apt install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
+RUN apt update && \
+    apt install -y automake cmake3 git gcc g++ libtool make pkg-config \
+        tar wget zlib1g-dev
+# ```
+
+# #### OpenSSL
+
+# Ubuntu:14.04 ships with a very old version of OpenSSL, this version is not
+# supported by gRPC. We need to compile and install OpenSSL-1.0.2 from source.
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://www.openssl.org/source/openssl-1.0.2n.tar.gz
+RUN tar xf openssl-1.0.2n.tar.gz
+WORKDIR /var/tmp/build/openssl-1.0.2n
+RUN ./config --shared
+RUN make -j ${NCPU:-4}
+RUN make install
+# ```
+
+# Note that by default OpenSSL installs itself in `/usr/local/ssl`. Installing
+# on a more conventional location, such as `/usr/local` or `/usr`, can break
+# many programs in your system. OpenSSL 1.0.2 is actually incompatible with
+# with OpenSSL 1.0.0 which is the version expected by the programs already
+# installed by Ubuntu 14.04.
+
+# In any case, as the library installs itself in this non-standard location, we
+# also need to configure CMake and other build program to find this version of
+# OpenSSL:
+
+# ```bash
+ENV OPENSSL_ROOT_DIR=/usr/local/ssl
+ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
+# ```
+
+# #### Protobuf
+
+# We need to install a version of Protobuf, recent enough that it supports the
+# Google Cloud Platform proto files:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### c-ares
+
+# Recent versions of gRPC require c-ares >= 1.11, while Ubuntu 14.04
+# distributes c-ares-1.10. Manually install a newer version:
+
+# ```bash
+@INSTALL_C_ARES_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We can install gRPC from source using:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
@@ -1,0 +1,59 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=xenial
+FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+# This is an automatically generated file, do not modify it directly, see
+#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+
+## [START INSTALL.md]
+
+# Install the minimal development tools, OpenSSL and libcurl:
+
+# ```bash
+RUN apt update && \
+    apt install -y automake build-essential cmake git gcc g++ \
+        libcurl4-openssl-dev libssl-dev libtool make \
+        pkg-config tar wget zlib1g-dev
+# ```
+
+# #### Protobuf
+
+# Likewise, manually install Protobuf:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### c-ares
+
+# Recent versions of gRPC require c-ares >= 1.11, while Ubuntu-16.04
+# distributes c-ares-1.10. Manually install a newer version:
+
+# ```bash
+@INSTALL_C_ARES_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We can install gRPC from source using:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=xenial
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
-
-# This is an automatically generated file, do not modify it directly, see
-#   https://github.com/googleapis/google-cloud-cpp-common/ci/templates
 
 ## [START INSTALL.md]
 

--- a/ci/templates/kokoro/install/build.sh
+++ b/ci/templates/kokoro/install/build.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ $# -eq 1 ]]; then
+  export DISTRO="${1}"
+elif [[ -n "${KOKORO_JOB_NAME:-}" ]]; then
+  # Kokoro injects the KOKORO_JOB_NAME environment variable, the value of this
+  # variable is cloud-cpp/<repo>/<config-file-name-without-cfg> (or more
+  # generally <path/to/config-file-without-cfg>). By convention we name these
+  # files `$foo.cfg` for continuous builds and `$foo-presubmit.cfg` for
+  # presubmit builds. Here we extract the value of "foo" and use it as the build
+  # name.
+  DISTRO="$(basename "${KOKORO_JOB_NAME}" "-presubmit")"
+  export DISTRO
+
+  # This is passed into the environment of the docker build and its scripts to
+  # tell them if they are running as part of a CI build rather than just a
+  # human invocation of "build.sh <build-name>". This allows scripts to be
+  # strict when run in a CI, but a little more friendly when run by a human.
+  RUNNING_CI="yes"
+  export RUNNING_CI
+else
+  echo "Aborting build as the distribution name is not defined."
+  echo "If you are invoking this script via the command line use:"
+  echo "    $0 <distro-name>"
+  echo
+  echo "If this script is invoked by Kokoro, the CI system is expected to set"
+  echo "the KOKORO_JOB_NAME environment variable."
+  exit 1
+fi
+
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
+
+echo "================================================================"
+echo "Change working directory to project root $(date)."
+cd "${PROJECT_ROOT}"
+
+echo "================================================================"
+echo "Building with ${NCPU} cores $(date) on ${PWD}."
+
+echo "================================================================"
+echo "Load Google Container Registry configuration parameters $(date)."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+
+echo "================================================================"
+echo "Setup Google Container Registry access $(date)."
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
+  gcloud auth activate-service-account --key-file \
+    "${KOKORO_GFILE_DIR}/gcr-service-account.json"
+fi
+gcloud auth configure-docker
+
+echo "================================================================"
+echo "Download existing image (if available) for ${DISTRO} $(date)."
+has_cache="false"
+if docker pull "${INSTALL_IMAGE}:latest"; then
+  echo "Existing image successfully downloaded."
+  has_cache="true"
+fi
+
+echo "================================================================"
+echo "Build base image with minimal development tools for ${DISTRO} $(date)."
+update_cache="false"
+
+devtools_flags=(
+  # Only build up to the stage that installs the minimal development tools, but
+  # does not compile any of our code.
+  "--target" "devtools"
+  # Create the image with the same tag as the cache we are using, so we can
+  # upload it.
+  "-t" "${INSTALL_IMAGE}:latest"
+  "--build-arg" "NCPU=${NCPU}"
+  "-f" "ci/kokoro/install/Dockerfile.${DISTRO}"
+)
+
+if "${has_cache}"; then
+  devtools_flags+=("--cache-from=${INSTALL_IMAGE}:latest")
+fi
+
+if [[ "${RUNNING_CI:-}" == "yes" ]] && \
+   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+  devtools_flags+=("--no-cache")
+fi
+
+echo "Running docker build with " "${devtools_flags[@]}"
+if docker build "${devtools_flags[@]}" ci; then
+   update_cache="true"
+fi
+
+if "${update_cache}" && [[ "${RUNNING_CI:-}" == "yes" ]] &&
+   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+  echo "================================================================"
+  echo "Uploading updated base image for ${DISTRO} $(date)."
+  # Do not stop the build on a failure to update the cache.
+  docker push "${INSTALL_IMAGE}:latest" || true
+fi
+
+echo "================================================================"
+echo "Run validation script for INSTALL instructions on ${DISTRO}."
+readonly INSTALL_RUN_IMAGE="${DOCKER_IMAGE_PREFIX}/ci-install-runtime-${DISTRO}"
+docker build -t "${INSTALL_RUN_IMAGE}" \
+  "--cache-from=${INSTALL_IMAGE}:latest" \
+  "--target=install" \
+  "--build-arg" "NCPU=${NCPU}" \
+  -f "ci/kokoro/install/Dockerfile.${DISTRO}" .
+echo "================================================================"
+
+source "${PROJECT_ROOT}/ci/etc/kokoro/install/run-installed-programs.sh"

--- a/ci/templates/kokoro/install/build.sh.in
+++ b/ci/templates/kokoro/install/build.sh.in
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+@WARNING_GENERATED_FILE_FRAGMENT@
 
 set -eu
 

--- a/ci/templates/kokoro/install/docker-fragments-functions.sh
+++ b/ci/templates/kokoro/install/docker-fragments-functions.sh
@@ -29,9 +29,12 @@ replace_fragments() {
   local sed_args=("-e" "s,@GOOGLE_CLOUD_CPP_REPOSITORY@,${GOOGLE_CLOUD_CPP_REPOSITORY},")
   for fragment in "${fragment_names[@]}"; do
     sed_args+=("-e" "s,@${fragment}@,$(/bin/echo -n "${!fragment}" |
-        tr '\n' '^' |
+        # Note the use of \003 ("End of Text") as the magic character to
+        # represent newlines. This must match the invert `tr` call below. It
+        # allows us to escape newlines in the sed expression.
+        tr '\n' '\003' |
         sed -e 's,\\,\\\\,g' -e 's/&/\\&/g' -e 's/,/\\,/g' -e 's/`/\\`/' ),")
   done
 
-  sed "${sed_args[@]}" | tr '^' '\n'
+  sed "${sed_args[@]}" | tr '\003' '\n'
 }

--- a/ci/templates/kokoro/install/docker-fragments-functions.sh
+++ b/ci/templates/kokoro/install/docker-fragments-functions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+read_into_variable() {
+  # Reading a heredoc into a variable with `read` always exits with an error.
+  read -r -d '' "${1}" || true;
+}
+
+# We need a way to replace "variables" into a chunk of text, but this is
+# complicated because the text may (and does) contain shell special characters.
+# So we use `sed` to replace @VAR@ by the value of the variable, which is also
+# complicated because the text may contain newlines, and sed special characters.
+# With enough escaping things work for our purposes.
+replace_fragments() {
+  local fragment_names=("$@")
+
+  local sed_args=("-e" "s,@GOOGLE_CLOUD_CPP_REPOSITORY@,${GOOGLE_CLOUD_CPP_REPOSITORY},")
+  for fragment in "${fragment_names[@]}"; do
+    sed_args+=("-e" "s,@${fragment}@,$(/bin/echo -n "${!fragment}" |
+        tr '\n' '^' |
+        sed -e 's,\\,\\\\,g' -e 's/&/\\&/g' -e 's/,/\\,/g' -e 's/`/\\`/' ),")
+  done
+
+  sed "${sed_args[@]}" | tr '^' '\n'
+}

--- a/ci/templates/kokoro/install/docker-fragments-functions.sh
+++ b/ci/templates/kokoro/install/docker-fragments-functions.sh
@@ -24,9 +24,9 @@ read_into_variable() {
 # complicated because the text may contain newlines, and sed special characters.
 # With enough escaping things work for our purposes.
 replace_fragments() {
-  local fragment_names=("$@")
+  local fragment_names=("$@" "GOOGLE_CLOUD_CPP_REPOSITORY")
 
-  local sed_args=("-e" "s,@GOOGLE_CLOUD_CPP_REPOSITORY@,${GOOGLE_CLOUD_CPP_REPOSITORY},")
+  local sed_args=()
   for fragment in "${fragment_names[@]}"; do
     sed_args+=("-e" "s,@${fragment}@,$(/bin/echo -n "${!fragment}" |
         # Note the use of \003 ("End of Text") as the magic character to

--- a/ci/templates/kokoro/install/docker-fragments.sh
+++ b/ci/templates/kokoro/install/docker-fragments.sh
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-read -r -d '' INSTALL_CPP_CMAKEFILES_FROM_SOURCE <<'_EOF_'
+read_into_variable WARNING_GENERATED_FILE_FRAGMENT <<'_EOF_'
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+_EOF_
+
+read_into_variable INSTALL_CPP_CMAKEFILES_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
 RUN tar -xf v0.1.5.tar.gz
@@ -25,7 +33,7 @@ RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
 
-read -r -d '' INSTALL_GOOGLETEST_FROM_SOURCE <<'_EOF_'
+read_into_variable INSTALL_GOOGLETEST_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
 RUN tar -xf release-1.10.0.tar.gz
@@ -38,7 +46,7 @@ RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
 
-read -r -d '' INSTALL_CRC32C_FROM_SOURCE <<'_EOF_'
+read_into_variable INSTALL_CRC32C_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
 RUN tar -xf 1.0.6.tar.gz
@@ -54,7 +62,7 @@ RUN cmake --build cmake-out/crc32c --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
 
-read -r -d '' INSTALL_PROTOBUF_FROM_SOURCE <<'_EOF_'
+read_into_variable INSTALL_PROTOBUF_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
 RUN tar -xf v3.9.1.tar.gz
@@ -68,7 +76,7 @@ RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
 
-read -r -d '' INSTALL_C_ARES_FROM_SOURCE <<'_EOF_'
+read_into_variable INSTALL_C_ARES_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
 RUN tar -xf cares-1_14_0.tar.gz
@@ -78,7 +86,7 @@ RUN make install
 RUN ldconfig
 _EOF_
 
-read -r -d '' INSTALL_GRPC_FROM_SOURCE <<'_EOF_'
+read_into_variable INSTALL_GRPC_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
 RUN tar -xf v1.23.1.tar.gz
@@ -88,7 +96,7 @@ RUN make install
 RUN ldconfig
 _EOF_
 
-read -r -d '' INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE <<'_EOF_'
+read_into_variable INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz
 RUN tar -xf v0.13.0.tar.gz
@@ -99,21 +107,3 @@ RUN cmake -H. -Bcmake-out \
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
-
-# We need a way to replace "variables" into a chunk of text, but this is
-# complicated because the text may (and does) contain shell special characters.
-# So we use `sed` to replace @VAR@ by the value of the variable, which is also
-# complicated because the text may contain newlines, and sed special characters.
-# With enough escaping things work for our purposes.
-replace_fragments() {
-  local fragment_names=("$@")
-
-  local sed_args=("-e" "s,@GOOGLE_CLOUD_CPP_REPOSITORY@,${GOOGLE_CLOUD_CPP_REPOSITORY},")
-  for fragment in "${fragment_names[@]}"; do
-    sed_args+=("-e" "s,@${fragment}@,$(/bin/echo -n "${!fragment}" |
-        tr '\n' '|' |
-        sed -e 's,\\,\\\\,g' -e 's/&/\\&/g' -e 's/,/\\,/g' -e 's/`/\\`/' ),")
-  done
-
-  sed "${sed_args[@]}" | tr '|' '\n'
-}

--- a/ci/templates/kokoro/install/docker-fragments.sh
+++ b/ci/templates/kokoro/install/docker-fragments.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+read -r -d '' INSTALL_CPP_CMAKEFILES_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
+RUN cmake \
+    -DBUILD_SHARED_LIBS=YES \
+    -H. -Bcmake-out
+RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
+RUN ldconfig
+_EOF_
+
+read -r -d '' INSTALL_GOOGLETEST_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+RUN tar -xf release-1.10.0.tar.gz
+WORKDIR /var/tmp/build/googletest-release-1.10.0
+RUN cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -H. -Bcmake-out
+RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
+RUN ldconfig
+_EOF_
+
+read -r -d '' INSTALL_CRC32C_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
+RUN tar -xf 1.0.6.tar.gz
+WORKDIR /var/tmp/build/crc32c-1.0.6
+RUN cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DCRC32C_BUILD_TESTS=OFF \
+      -DCRC32C_BUILD_BENCHMARKS=OFF \
+      -DCRC32C_USE_GLOG=OFF \
+      -H. -Bcmake-out/crc32c
+RUN cmake --build cmake-out/crc32c --target install -- -j ${NCPU:-4}
+RUN ldconfig
+_EOF_
+
+read -r -d '' INSTALL_PROTOBUF_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+RUN tar -xf v3.9.1.tar.gz
+WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
+RUN cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -Bcmake-out
+RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
+RUN ldconfig
+_EOF_
+
+read -r -d '' INSTALL_C_ARES_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
+RUN tar -xf cares-1_14_0.tar.gz
+WORKDIR /var/tmp/build/c-ares-cares-1_14_0
+RUN ./buildconf && ./configure && make -j ${NCPU:-4}
+RUN make install
+RUN ldconfig
+_EOF_
+
+read -r -d '' INSTALL_GRPC_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+RUN tar -xf v1.23.1.tar.gz
+WORKDIR /var/tmp/build/grpc-1.23.1
+RUN make -j ${NCPU:-4}
+RUN make install
+RUN ldconfig
+_EOF_
+
+read -r -d '' INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz
+RUN tar -xf v0.13.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.13.0
+RUN cmake -H. -Bcmake-out \
+    -DBUILD_TESTING=OFF \
+    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
+RUN ldconfig
+_EOF_
+
+# We need a way to replace "variables" into a chunk of text, but this is
+# complicated because the text may (and does) contain shell special characters.
+# So we use `sed` to replace @VAR@ by the value of the variable, which is also
+# complicated because the text may contain newlines, and sed special characters.
+# With enough escaping things work for our purposes.
+replace_fragments() {
+  local fragment_names=("$@")
+
+  local sed_args=("-e" "s,@GOOGLE_CLOUD_CPP_REPOSITORY@,${GOOGLE_CLOUD_CPP_REPOSITORY},")
+  for fragment in "${fragment_names[@]}"; do
+    sed_args+=("-e" "s,@${fragment}@,$(/bin/echo -n "${!fragment}" |
+        tr '\n' '|' |
+        sed -e 's,\\,\\\\,g' -e 's/&/\\&/g' -e 's/,/\\,/g' -e 's/`/\\`/' ),")
+  done
+
+  sed "${sed_args[@]}" | tr '|' '\n'
+}


### PR DESCRIPTION
This PR introduces scripts and configuration files to automatically
generate `ci/kokoro/install`, but does not change the files in that
directory. The idea is to give folks a chance to evaluate the generators
by themselves before we decide this is the way to go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/72)
<!-- Reviewable:end -->
