### PR TITLE
docs: fix instructions for CentOS 7 (and others)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -172,6 +172,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -190,6 +191,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -238,6 +240,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -256,6 +259,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -313,6 +317,7 @@ cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -359,6 +364,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -377,6 +383,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -421,6 +428,7 @@ cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -452,6 +460,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -470,6 +479,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -514,6 +524,7 @@ cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -560,6 +571,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -578,6 +590,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -654,6 +667,7 @@ cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -700,6 +714,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -718,6 +733,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -767,6 +783,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -785,6 +802,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -836,6 +854,7 @@ cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -867,6 +886,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -885,6 +905,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -941,6 +962,7 @@ cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -972,6 +994,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -990,6 +1013,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -1052,6 +1076,7 @@ cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -1098,6 +1123,7 @@ cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
@@ -1116,6 +1142,7 @@ cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,8 +150,8 @@ sudo dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel
 ```
 
-Fedora includes packages for gRPC, libcurl, and OpenSSL that are recent enough
-for `google-cloud-cpp`. Install these packages and additional development
+Fedora 30 includes packages for gRPC, libcurl, and OpenSSL that are recent
+enough for the project. Install these packages and additional development
 tools to compile the dependencies:
 
 ```bash
@@ -162,7 +162,7 @@ sudo dnf install -y grpc-devel grpc-plugins \
 
 #### googleapis
 
-There is no Fedora package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -194,23 +194,23 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-We can now compile and install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
 
 ### openSUSE (Tumbleweed)
 
-Install the minimal development tools:
+Install the minimal development tools, libcurl and OpenSSL:
 
 ```bash
 sudo zypper refresh && \
@@ -218,18 +218,17 @@ sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
         libcurl-devel libopenssl-devel make tar wget zlib-devel
 ```
 
-openSUSE Tumbleweed provides packages for gRPC, libcurl, and protobuf, and the
-versions of these packages are recent enough to support the Google Cloud
-Platform proto files.
+The versions of gRPC and Protobuf packaged with openSUSE/Tumbleweed are recent
+enough to support the Google Cloud Platform proto files.
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install -y grpc-devel gzip libcurl-devel tar wget
+sudo zypper install -y grpc-devel
 ```
 
 #### googleapis
 
-There is no OpenSUSE package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -261,41 +260,54 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-We can now compile and install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
 
 ### openSUSE (Leap)
 
-Install the minimal development tools:
+Install the minimal development tools, libcurl and OpenSSL. The gRPC Makefile
+uses `which` to determine whether the compiler is available. Install this
+command for the extremely rare case where it may be missing from your
+workstation or build server.
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
-        libcurl-devel libopenssl-devel make tar wget
+sudo zypper install --allow-downgrade -y automake cmake gcc gcc-c++ git gzip \
+        libcurl-devel libopenssl-devel libtool make tar wget which
+```
+
+The following steps will install libraries and tools in `/usr/local`. openSUSE
+does not search for shared libraries in these directories by default, there
+are multiple ways to solve this problem, the following steps are one solution:
+
+```bash
+(echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+sudo tee /etc/ld.so.conf.d/usrlocal.conf
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+export PATH=/usr/local/bin:${PATH}
 ```
 
 #### Protobuf
 
-OpenSUSE Leap includes a package for protobuf-2.6, but this is too old to
-support the Google Cloud Platform proto files, or to support gRPC for that
-matter. Manually install protobuf:
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-tar -xf v3.6.1.tar.gz
-cd $HOME/Downloads/protobuf-3.6.1/cmake
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+tar -xf v3.9.1.tar.gz
+cd $HOME/Downloads/protobuf-3.9.1/cmake
 cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -307,16 +319,8 @@ sudo ldconfig
 
 #### c-ares
 
-Recent versions of gRPC require c-ares >= 1.11, while OpenSUSE Leap
-distributes c-ares-1.9. We need some additional development tools to compile
-this library:
-
-```bash
-sudo zypper refresh && \
-sudo zypper install -y automake libtool
-```
-
-Manually install a newer version:
+Recent versions of gRPC require c-ares >= 1.11, while openSUSE/Leap
+distributes c-ares-1.9. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
@@ -330,25 +334,14 @@ sudo ldconfig
 
 #### gRPC
 
-The gRPC Makefile uses `which` to determine whether the compiler is available.
-Install this command for the extremely rare case where it may be missing from
-your workstation or build server:
-
-```bash
-sudo zypper refresh && \
-sudo zypper install -y which
-```
-
-Then gRPC can be manually installed using:
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-tar -xf v1.19.1.tar.gz
-cd $HOME/Downloads/grpc-1.19.1
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-export PATH=/usr/local/bin:${PATH}
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+tar -xf v1.23.1.tar.gz
+cd $HOME/Downloads/grpc-1.23.1
 make -j ${NCPU:-4}
 sudo make install
 sudo ldconfig
@@ -356,7 +349,7 @@ sudo ldconfig
 
 #### googleapis
 
-There is no OpenSUSE package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -388,23 +381,23 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-We can now compile and install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
 
 ### Ubuntu (18.04 - Bionic Beaver)
 
-Install the minimal development tools:
+Install the minimal development tools, libcurl, OpenSSL and libc-ares:
 
 ```bash
 sudo apt update && \
@@ -415,15 +408,14 @@ sudo apt install -y build-essential cmake git gcc g++ cmake \
 
 #### Protobuf
 
-While protobuf-3.0 is distributed with Ubuntu, the Google Cloud Plaform proto
-files require more recent versions (circa 3.4.x). To manually install a more
-recent version use:
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-tar -xf v3.6.1.tar.gz
-cd $HOME/Downloads/protobuf-3.6.1/cmake
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+tar -xf v3.9.1.tar.gz
+cd $HOME/Downloads/protobuf-3.9.1/cmake
 cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -435,14 +427,14 @@ sudo ldconfig
 
 #### gRPC
 
-Likewise, Ubuntu has packages for grpc-1.3.x, but this version is too old for
-the Google Cloud Platform APIs:
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-tar -xf v1.19.1.tar.gz
-cd $HOME/Downloads/grpc-1.19.1
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+tar -xf v1.23.1.tar.gz
+cd $HOME/Downloads/grpc-1.23.1
 make -j ${NCPU:-4}
 sudo make install
 sudo ldconfig
@@ -450,7 +442,7 @@ sudo ldconfig
 
 #### googleapis
 
-There is no Ubuntu package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -482,42 +474,41 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-Finally we can install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
 
 ### Ubuntu (16.04 - Xenial Xerus)
 
-Install the minimal development tools:
+Install the minimal development tools, OpenSSL and libcurl:
 
 ```bash
 sudo apt update && \
-sudo apt install -y build-essential cmake git gcc g++ cmake \
-        libcurl4-openssl-dev libssl-dev make \
+sudo apt install -y automake build-essential cmake git gcc g++ \
+        libcurl4-openssl-dev libssl-dev libtool make \
         pkg-config tar wget zlib1g-dev
 ```
 
 #### Protobuf
 
-While protobuf-2.6 is distributed with Ubuntu-16.04, the Google Cloud Plaform
-proto files require more recent versions (circa 3.4.x). To manually install a
-more recent version use:
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-tar -xf v3.6.1.tar.gz
-cd $HOME/Downloads/protobuf-3.6.1/cmake
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+tar -xf v3.9.1.tar.gz
+cd $HOME/Downloads/protobuf-3.9.1/cmake
 cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -530,16 +521,7 @@ sudo ldconfig
 #### c-ares
 
 Recent versions of gRPC require c-ares >= 1.11, while Ubuntu-16.04
-distributes c-ares-1.10. We need some additional development tools to compile
-this library:
-
-```bash
-sudo apt update && \
-sudo apt install -y automake libtool
-```
-
-After installing these tools we can manually install a newer version
-of c-ares:
+distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
@@ -553,14 +535,14 @@ sudo ldconfig
 
 #### gRPC
 
-Ubuntu-16.04 does not provide packages for the C++ gRPC bindings, install the
-library manually:
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We can install gRPC from source using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-tar -xf v1.19.1.tar.gz
-cd $HOME/Downloads/grpc-1.19.1
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+tar -xf v1.23.1.tar.gz
+cd $HOME/Downloads/grpc-1.23.1
 make -j ${NCPU:-4}
 sudo make install
 sudo ldconfig
@@ -568,7 +550,7 @@ sudo ldconfig
 
 #### googleapis
 
-There is no Ubuntu package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -600,16 +582,16 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-Finally we can install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
@@ -623,9 +605,11 @@ We use the `ubuntu-toolchain-r` PPA to get a modern version of CMake:
 sudo apt update && sudo apt install -y software-properties-common
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt update && \
-sudo apt install -y cmake3 git gcc g++ make pkg-config tar wget \
-        zlib1g-dev
+sudo apt install -y automake cmake3 git gcc g++ libtool make pkg-config \
+        tar wget zlib1g-dev
 ```
+
+#### OpenSSL
 
 Ubuntu:14.04 ships with a very old version of OpenSSL, this version is not
 supported by gRPC. We need to compile and install OpenSSL-1.0.2 from source.
@@ -655,33 +639,16 @@ export OPENSSL_ROOT_DIR=/usr/local/ssl
 export PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
 ```
 
-#### libcurl.
-
-Because google-cloud-cpp uses both gRPC and curl, we need to compile libcurl
-against the same version of OpenSSL:
-
-```bash
-cd $HOME/Downloads
-wget -q https://curl.haxx.se/download/curl-7.61.0.tar.gz
-tar xf curl-7.61.0.tar.gz
-cd $HOME/Downloads/curl-7.61.0
-./configure --prefix=/usr/local/curl
-make -j ${NCPU:-4}
-sudo make install
-sudo ldconfig
-```
-
 #### Protobuf
 
-While protobuf-2.5 is distributed with Ubuntu:trusty, the Google Cloud Plaform
-proto files require more recent versions (circa 3.4.x). To manually install a
-more recent version use:
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-tar -xf v3.6.1.tar.gz
-cd $HOME/Downloads/protobuf-3.6.1/cmake
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+tar -xf v3.9.1.tar.gz
+cd $HOME/Downloads/protobuf-3.9.1/cmake
 cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -693,17 +660,8 @@ sudo ldconfig
 
 #### c-ares
 
-Recent versions of gRPC require c-ares >= 1.11, while Ubuntu-16.04
-distributes c-ares-1.10. We need some additional development tools to compile
-this library:
-
-```bash
-sudo apt update && \
-sudo apt install -y automake libtool
-```
-
-After installing these tools we can manually install a newer version
-of c-ares:
+Recent versions of gRPC require c-ares >= 1.11, while Ubuntu 14.04
+distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
@@ -712,26 +670,27 @@ tar -xf cares-1_14_0.tar.gz
 cd $HOME/Downloads/c-ares-cares-1_14_0
 ./buildconf && ./configure && make -j ${NCPU:-4}
 sudo make install
+sudo ldconfig
 ```
 
 #### gRPC
 
-Ubuntu:trusty does not provide a package for gRPC. Manually install this
-library:
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We can install gRPC from source using:
 
 ```bash
-export PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig:/usr/local/curl/lib/pkgconfig
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-tar -xf v1.19.1.tar.gz
-cd $HOME/Downloads/grpc-1.19.1
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+tar -xf v1.23.1.tar.gz
+cd $HOME/Downloads/grpc-1.23.1
 make -j ${NCPU:-4}
 sudo make install
+sudo ldconfig
 ```
 
 #### googleapis
 
-There is no Ubuntu package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -763,37 +722,42 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-We can now compile and install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
-cmake -H. -Bcmake-out \
-    -DCMAKE_FIND_ROOT_PATH="/usr/local/curl;/usr/local/ssl"
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cd $HOME/project
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
 
 ### Debian (10 - Buster)
 
-First install the development tools. Debian 10 includes sufficiently recent
-versions of gRPC and Protobuf, so we use the pre-built versions.
+Install the minimal development tools, libcurl, and OpenSSL:
 
 ```bash
 sudo apt update && \
 sudo apt install -y build-essential cmake git gcc g++ cmake \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libgrpc++-dev \
-        libprotobuf-dev libssl-dev make pkg-config \
-        protobuf-compiler protobuf-compiler-grpc tar wget zlib1g-dev
+        libcurl4-openssl-dev libssl-dev make pkg-config tar wget zlib1g-dev
+```
+
+Debian 10 includes versions of gRPC and Protobuf that support the
+Google Cloud Platform proto files. We simply install these pre-built versions:
+
+```bash
+sudo apt update && \
+sudo apt install -y libgrpc++-dev libprotobuf-dev \
+        protobuf-compiler protobuf-compiler-grpc
 ```
 
 #### googleapis
 
-There is no Debian package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -825,16 +789,16 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-Finally we can install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
@@ -842,7 +806,7 @@ sudo cmake --build . --target install
 ### Debian (9 - Stretch)
 
 First install the development tools and libcurl.
-On Debian Stretch, libcurl links against openssl-1.0.2, and one must link
+On Debian 9, libcurl links against openssl-1.0.2, and one must link
 against the same version or risk an inconsistent configuration of the library.
 This is especially important for multi-threaded applications, as openssl-1.0.2
 requires explicitly setting locking callbacks. Therefore, to use libcurl one
@@ -859,100 +823,8 @@ sudo apt install -y build-essential cmake git gcc g++ cmake \
 
 #### Protobuf
 
-While protobuf-3.0 is distributed with Ubuntu, the Google Cloud Plaform proto
-files require more recent versions (circa 3.4.x). To manually install a more
-recent version use:
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-tar -xf v3.6.1.tar.gz
-cd $HOME/Downloads/protobuf-3.6.1/cmake
-cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DBUILD_SHARED_LIBS=yes \
-        -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
-sudo ldconfig
-```
-
-#### gRPC
-
-Likewise, Ubuntu has packages for grpc-1.3.x, but this version is too old for
-the Google Cloud Platform APIs:
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-tar -xf v1.19.1.tar.gz
-cd $HOME/Downloads/grpc-1.19.1
-make -j ${NCPU:-4}
-sudo make install
-sudo ldconfig
-```
-
-#### googleapis
-
-There is no Debian package for this library. To install it, use:
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
-sudo ldconfig
-```
-
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
-sudo ldconfig
-```
-
-#### google-cloud-cpp
-
-Finally we can install `google-cloud-cpp`.
-
-```bash
-cd $HOME/google-cloud-cpp
-cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
-sudo cmake --build . --target install
-```
-
-
-### CentOS (8)
-
-Install the minimal development tools:
-
-```bash
-sudo dnf makecache && \
-sudo dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
-        zlib-devel libcurl-devel c-ares-devel tar wget which
-```
-
-#### Protobuf
-
-Likewise, manually install Protobuf:
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
@@ -970,23 +842,14 @@ sudo ldconfig
 
 #### gRPC
 
-gRPC also requires a manual install. gRPC uses `pkg-config` to find protobuf,
-as we installed this library in `/usr/local/*` we need to change the
-environment variables used by `pkg-config` to find modules:
-
-```bash
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-export PATH=/usr/local/bin:${PATH}
-```
-
-Once the environment is setup, we can compile gRPC:
+To install gRPC we first need to configure pkg-config to find the version of
+Protobuf we just installed in `/usr/local`:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.24.3.tar.gz
-tar -xf v1.24.3.tar.gz
-cd $HOME/Downloads/grpc-1.24.3
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+tar -xf v1.23.1.tar.gz
+cd $HOME/Downloads/grpc-1.23.1
 make -j ${NCPU:-4}
 sudo make install
 sudo ldconfig
@@ -994,7 +857,7 @@ sudo ldconfig
 
 #### googleapis
 
-There is no Fedora package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -1026,16 +889,121 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-We can now compile and install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
+sudo cmake --build . --target install
+```
+
+
+### CentOS (8)
+
+Install the minimal development tools, libcurl, OpenSSL, and the c-ares
+library (required by gRPC):
+
+```bash
+sudo dnf makecache && \
+sudo dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+        zlib-devel libcurl-devel c-ares-devel tar wget which
+```
+
+The following steps will install libraries and tools in `/usr/local`. By
+default CentOS-8 does not search for shared libraries in these directories,
+there are multiple ways to solve this problem, the following steps are one
+solution:
+
+```bash
+(echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+sudo tee /etc/ld.so.conf.d/usrlocal.conf
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+export PATH=/usr/local/bin:${PATH}
+```
+
+#### Protobuf
+
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+tar -xf v3.9.1.tar.gz
+cd $HOME/Downloads/protobuf-3.9.1/cmake
+cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -Bcmake-out
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+sudo ldconfig
+```
+
+#### gRPC
+
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We manually install it using:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+tar -xf v1.23.1.tar.gz
+cd $HOME/Downloads/grpc-1.23.1
+make -j ${NCPU:-4}
+sudo make install
+sudo ldconfig
+```
+
+#### googleapis
+
+We need a recent version of the Google Cloud Platform proto C++ libraries:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
+cmake \
+    -DBUILD_SHARED_LIBS=YES \
+    -H. -Bcmake-out
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+sudo ldconfig
+```
+
+#### googletest
+
+We need a recent version of GoogleTest to compile the unit and integration
+tests.
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+tar -xf release-1.10.0.tar.gz
+cd $HOME/Downloads/googletest-release-1.10.0
+cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -H. -Bcmake-out
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+sudo ldconfig
+```
+
+#### Compile and install the main project
+
+We can now compile, test, and install `google-cloud-cpp-common`.
+
+```bash
+cd $HOME/project
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 
@@ -1043,29 +1011,42 @@ sudo cmake --build . --target install
 ### CentOS (7)
 
 First install the development tools and OpenSSL. The development tools
-distributed with CentOS (notably CMake) are too old to build
-`google-cloud-cpp`. In these instructions, we use `cmake3` obtained from
+distributed with CentOS 7 (notably CMake) are too old to build
+the project. In these instructions, we use `cmake3` obtained from
 [Software Collections](https://www.softwarecollections.org/).
 
 ```bash
-rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-sudo yum install -y centos-release-scl
+sudo rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+sudo yum install -y centos-release-scl yum-utils
 sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
 sudo yum makecache && \
 sudo yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar wget which zlib-devel
-ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
+sudo ln -sf /usr/bin/cmake3 /usr/bin/cmake && sudo ln -sf /usr/bin/ctest3 /usr/bin/ctest
+```
+
+The following steps will install libraries and tools in `/usr/local`. By
+default CentOS-7 does not search for shared libraries in these directories,
+there are multiple ways to solve this problem, the following steps are one
+solution:
+
+```bash
+(echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+sudo tee /etc/ld.so.conf.d/usrlocal.conf
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+export PATH=/usr/local/bin:${PATH}
 ```
 
 #### Protobuf
 
-Likewise, manually install protobuf:
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-tar -xf v3.6.1.tar.gz
-cd $HOME/Downloads/protobuf-3.6.1/cmake
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+tar -xf v3.9.1.tar.gz
+cd $HOME/Downloads/protobuf-3.9.1/cmake
 cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -1092,16 +1073,14 @@ sudo ldconfig
 
 #### gRPC
 
-Can be manually installed using:
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-tar -xf v1.19.1.tar.gz
-cd $HOME/Downloads/grpc-1.19.1
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-export PATH=/usr/local/bin:${PATH}
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
+tar -xf v1.23.1.tar.gz
+cd $HOME/Downloads/grpc-1.23.1
 make -j ${NCPU:-4}
 sudo make install
 sudo ldconfig
@@ -1109,7 +1088,7 @@ sudo ldconfig
 
 #### googleapis
 
-There is no CentOS package for this library. To install it, use:
+We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
@@ -1141,16 +1120,16 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
 ```
 
-#### google-cloud-cpp
+#### Compile and install the main project
 
-Finally we can install `google-cloud-cpp`.
+We can now compile, test, and install `google-cloud-cpp-common`.
 
 ```bash
-cd $HOME/Downloads/google-cloud-cpp
+cd $HOME/project
 cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-cd $HOME/Downloads/google-cloud-cpp/cmake-out
-ctest --output-on-failure
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
 sudo cmake --build . --target install
 ```
 

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -24,7 +24,6 @@ declare -A ORIGINAL_COPYRIGHT_YEAR=(
   [ubuntu-trusty]=2018
   [ubuntu-xenial]=2018
   [ubuntu-bionic]=2018
-
 )
 
 BUILD_AND_TEST_PROJECT_FRAGMENT=$(replace_fragments \
@@ -56,12 +55,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -66,6 +66,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -112,6 +113,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -130,6 +132,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -31,7 +31,7 @@ ARG NCPU=4
 
 # ```bash
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y centos-release-scl
+RUN yum install -y centos-release-scl yum-utils
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && \
     yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
@@ -39,9 +39,21 @@ RUN yum makecache && \
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
 # ```
 
+# The following steps will install libraries and tools in `/usr/local`. By
+# default CentOS-7 does not search for shared libraries in these directories,
+# there are multiple ways to solve this problem, the following steps are one
+# solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV PATH=/usr/local/bin:${PATH}
+# ```
+
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -75,15 +87,8 @@ RUN ldconfig
 
 # #### gRPC
 
-# To install gRPC we first need to configure pkg-config to find the version of
-# Protobuf we just installed in `/usr/local`:
-
-# ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-# ```
-
-# Then we install it using:
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We manually install it using:
 
 # ```bash
 WORKDIR /var/tmp/build
@@ -138,12 +143,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -33,9 +33,21 @@ RUN dnf makecache && \
         zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 
+# The following steps will install libraries and tools in `/usr/local`. By
+# default CentOS-8 does not search for shared libraries in these directories,
+# there are multiple ways to solve this problem, the following steps are one
+# solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV PATH=/usr/local/bin:${PATH}
+# ```
+
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -54,15 +66,8 @@ RUN ldconfig
 
 # #### gRPC
 
-# To install gRPC we first need to configure pkg-config to find the version of
-# Protobuf we just installed in `/usr/local`:
-
-# ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-# ```
-
-# Then we install it using:
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We manually install it using:
 
 # ```bash
 WORKDIR /var/tmp/build
@@ -117,12 +122,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -60,6 +60,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -91,6 +92,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -109,6 +111,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -53,6 +53,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -71,6 +72,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -84,12 +84,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -55,6 +55,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -86,6 +87,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -104,6 +106,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -42,7 +42,7 @@ RUN apt update && \
 
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -117,12 +117,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -54,6 +54,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -72,6 +73,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -85,12 +85,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -61,6 +61,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -107,6 +108,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -125,6 +127,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -35,9 +35,20 @@ RUN zypper refresh && \
         libcurl-devel libopenssl-devel libtool make tar wget which
 # ```
 
+# The following steps will install libraries and tools in `/usr/local`. openSUSE
+# does not search for shared libraries in these directories by default, there
+# are multiple ways to solve this problem, the following steps are one solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV PATH=/usr/local/bin:${PATH}
+# ```
+
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -72,15 +83,7 @@ RUN ldconfig
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
-# Cloud Platform proto files, first configure pkg-config to find the version of
-# Protobuf we just installed in `/usr/local`:
-
-# ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-# ```
-
-# The we install it using:
+# Cloud Platform proto files. We manually install it using:
 
 # ```bash
 WORKDIR /var/tmp/build
@@ -135,12 +138,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -52,6 +52,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -70,6 +71,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -83,12 +83,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -35,7 +35,7 @@ RUN apt update && \
 
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -110,12 +110,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -48,6 +48,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -79,6 +80,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -97,6 +99,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/install/Dockerfile.ubuntu-trusty
@@ -67,7 +67,7 @@ ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
 
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -157,12 +157,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/install/Dockerfile.ubuntu-trusty
@@ -80,6 +80,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -126,6 +127,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -144,6 +146,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -48,6 +48,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -94,6 +95,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```
@@ -112,6 +114,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -35,7 +35,8 @@ RUN apt update && \
 
 # #### Protobuf
 
-# Likewise, manually install Protobuf:
+# We need to install a version of Protobuf that is recent enough to support the
+# Google Cloud Platform proto files:
 
 # ```bash
 WORKDIR /var/tmp/build
@@ -124,12 +125,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/templates/kokoro/install/Dockerfile.centos-7.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-7.in
@@ -27,7 +27,7 @@ ARG NCPU=4
 
 # ```bash
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y centos-release-scl
+RUN yum install -y centos-release-scl yum-utils
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && \
     yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
@@ -35,9 +35,21 @@ RUN yum makecache && \
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
 # ```
 
+# The following steps will install libraries and tools in `/usr/local`. By
+# default CentOS-7 does not search for shared libraries in these directories,
+# there are multiple ways to solve this problem, the following steps are one
+# solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV PATH=/usr/local/bin:${PATH}
+# ```
+
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -55,15 +67,8 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/cte
 
 # #### gRPC
 
-# To install gRPC we first need to configure pkg-config to find the version of
-# Protobuf we just installed in `/usr/local`:
-
-# ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-# ```
-
-# Then we install it using:
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We manually install it using:
 
 # ```bash
 @INSTALL_GRPC_FROM_SOURCE@

--- a/ci/templates/kokoro/install/Dockerfile.centos-8.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-8.in
@@ -29,9 +29,21 @@ RUN dnf makecache && \
         zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 
+# The following steps will install libraries and tools in `/usr/local`. By
+# default CentOS-8 does not search for shared libraries in these directories,
+# there are multiple ways to solve this problem, the following steps are one
+# solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV PATH=/usr/local/bin:${PATH}
+# ```
+
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -40,15 +52,8 @@ RUN dnf makecache && \
 
 # #### gRPC
 
-# To install gRPC we first need to configure pkg-config to find the version of
-# Protobuf we just installed in `/usr/local`:
-
-# ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-# ```
-
-# Then we install it using:
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We manually install it using:
 
 # ```bash
 @INSTALL_GRPC_FROM_SOURCE@

--- a/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
+++ b/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
@@ -38,7 +38,7 @@ RUN apt update && \
 
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash

--- a/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
+++ b/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
@@ -31,9 +31,20 @@ RUN zypper refresh && \
         libcurl-devel libopenssl-devel libtool make tar wget which
 # ```
 
+# The following steps will install libraries and tools in `/usr/local`. openSUSE
+# does not search for shared libraries in these directories by default, there
+# are multiple ways to solve this problem, the following steps are one solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV PATH=/usr/local/bin:${PATH}
+# ```
+
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash
@@ -52,15 +63,7 @@ RUN zypper refresh && \
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
-# Cloud Platform proto files, first configure pkg-config to find the version of
-# Protobuf we just installed in `/usr/local`:
-
-# ```bash
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-# ```
-
-# The we install it using:
+# Cloud Platform proto files. We manually install it using:
 
 # ```bash
 @INSTALL_GRPC_FROM_SOURCE@

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
@@ -31,7 +31,7 @@ RUN apt update && \
 
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-trusty.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-trusty.in
@@ -63,7 +63,7 @@ ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
 
 # #### Protobuf
 
-# We need to install a version of Protobuf, recent enough that it supports the
+# We need to install a version of Protobuf that is recent enough to support the
 # Google Cloud Platform proto files:
 
 # ```bash

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
@@ -31,7 +31,8 @@ RUN apt update && \
 
 # #### Protobuf
 
-# Likewise, manually install Protobuf:
+# We need to install a version of Protobuf that is recent enough to support the
+# Google Cloud Platform proto files:
 
 # ```bash
 @INSTALL_PROTOBUF_FROM_SOURCE@

--- a/ci/templates/kokoro/install/docker-fragments.sh
+++ b/ci/templates/kokoro/install/docker-fragments.sh
@@ -29,6 +29,7 @@ WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
@@ -42,6 +43,7 @@ RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
@@ -57,8 +59,9 @@ RUN cmake \
       -DCRC32C_BUILD_TESTS=OFF \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
-      -H. -Bcmake-out/crc32c
-RUN cmake --build cmake-out/crc32c --target install -- -j ${NCPU:-4}
+      -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
 
@@ -72,6 +75,7 @@ RUN cmake \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
         -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_
@@ -104,6 +108,7 @@ WORKDIR /var/tmp/build/google-cloud-cpp-common-0.13.0
 RUN cmake -H. -Bcmake-out \
     -DBUILD_TESTING=OFF \
     -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 _EOF_

--- a/ci/test-readme/dockerfile2markdown.sh
+++ b/ci/test-readme/dockerfile2markdown.sh
@@ -17,29 +17,59 @@
 set -eu
 
 # shellcheck disable=SC2016
-sed \
-    -e '/^## \[START IGNORED\]/,/^## \[END IGNORED\]/d' \
-    -e '/^FROM /d' \
-    -e '/^ARG /d' \
-    -e '/^## /d' \
-    -e 's/^# //' \
-    -e 's/^WORKDIR /cd /' \
-    -e 's/^RUN //' \
-    -e 's|/retry3 ||' \
-    -e 's/^ENV /export /' \
-    -e '/^COPY /d' \
-    -e 's/update-alternatives/sudo update-alternatives/g' \
-    -e 's/add-apt-repository/sudo add-apt-repository/g' \
-    -e 's/apt /sudo apt /g' \
-    -e 's/dnf/sudo dnf/g' \
-    -e 's/yum/sudo yum/g' \
-    -e 's/zypper/sudo zypper/g' \
-    -e 's/ldconfig/sudo ldconfig/g' \
-    -e 's/^\(cmake.*--target install.*\)/sudo \1/g' \
-    -e 's/^make install/sudo make install/' \
-    -e 's;/home/build;$HOME;' \
-    -e 's;/var/tmp/build;$HOME/Downloads;' \
-    -e 's/^    sudo/sudo/' "$@" | \
+sed_args=(
+    # Delete any sections marked as ignored.
+    '-e' '/^## \[START IGNORED\]/,/^## \[END IGNORED\]/d'
+    # Remove the Docker commands to define the base image and/or copy files.
+    '-e' '/^FROM /d'
+    '-e' '/^ARG /d'
+    '-e' '/^COPY /d'
+    # Things that are double comments are removed. This allows us to insert
+    # comments in the Dockerfile that are not transferred to the image.
+    '-e' '/^## /d'
+    # Regular comments are converted to text, this is where we put most of the
+    # markdown and explanations we intend to output to the INSTALL or README
+    # file
+    '-e' 's/^# //'
+    # Regular Dockerfile commands just become commands.
+    '-e' 's/^RUN //'
+    # Change some Dockerfile commands to the shell counterparts
+    '-e' 's/^WORKDIR /cd /'
+    '-e' 's/^ENV /export /'
+    # To workaround transient download failures the CI builds execute some
+    # commands 3 times, we do not need that in the README or INSTALL
+    # instructions
+    '-e' 's,/retry3 ,,'
+    # A number of commands need to be executed as sudo when the user is running
+    # them. The Dockerfile runs as root, and does not need the sudo prefix, but
+    # also, sudo may not even be installed.
+    '-e' 's/update-alternatives/sudo update-alternatives/g'
+    '-e' 's/add-apt-repository/sudo add-apt-repository/g'
+    '-e' 's/apt /sudo apt /g'
+    '-e' 's/dnf /sudo dnf /g'
+    '-e' 's/rpm /sudo rpm /g'
+    '-e' 's/yum /sudo yum /g'
+    '-e' 's/yum-config-manager /sudo yum-config-manager /g'
+    '-e' 's/zypper /sudo zypper /g'
+    '-e' 's/ldconfig/sudo ldconfig/g'
+    # Any 'make install' or 'cmake ... --target install' commands need sudo.
+    '-e' 's/\(cmake.*--target install.*\)/sudo \1/g'
+    '-e' 's/make install/sudo make install/'
+    # A standard technique to write files with root permissions is tee.
+    '-e' 's,tee /,sudo tee /,g'
+    # In some cases we link paths in /usr/bin, this is a bit too generous of a
+    # match, but works in practice.
+    '-e' 's/ln -sf /sudo ln -sf /g'
+    # The Dockerfile can use absolute paths for some directories, in the README
+    # or INSTALL instructions we prefer to use $HOME
+    '-e' 's;/home/build;$HOME;'
+    '-e' 's;/var/tmp/build;$HOME/Downloads;'
+    # Remove additional indentation for the sudo commands. The Docker files
+    # are more readable with the indentation, the markdown files not so much.
+    '-e' 's/^    sudo/sudo/'
+)
+
+sed "${sed_args[@]}" "$@" | \
     awk '
       BEGIN {
         removing_blanks=0;


### PR DESCRIPTION
I started by porting the changes from google-cloud-cpp to fix the
CentOS-7 and openSUSE/Leap instructions. In the process I noted that
using /o as the output directory was good for a Docker image, but not
for the instructions we generate from them (as I think @mr-salty tried
to tell me), so I fixed that too. Then I regenerated INSTALL.md with the
missing `sudo` commands.

This fixes #82. Note that `INSTALL.md` and `ci/kokoro/install/*` are
generated files, you may want to skip them and just look at the sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/84)
<!-- Reviewable:end -->
