### PR TITLE
fix: std::apply doesn't work for std::tuple<>&

### DIFF
--- a/google/cloud/internal/tuple.h
+++ b/google/cloud/internal/tuple.h
@@ -51,15 +51,17 @@ struct ApplyRes<F, std::tuple<Args...>> {
  * @tparam I indices 0..(sizeof(Tuple)-1)
  */
 template <class F, class Tuple, std::size_t... I>
-typename ApplyRes<F, Tuple>::type ApplyImpl(F&& f, Tuple&& t,
-                                            index_sequence<I...>) {
+typename ApplyRes<F, typename std::decay<Tuple>::type>::type ApplyImpl(
+    F&& f, Tuple&& t, index_sequence<I...>) {
   return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
 }
 
 // Reimplementation of `std::apply` from C++14
 template <class F, class Tuple>
-typename ApplyRes<F, Tuple>::type apply(F&& f, Tuple&& t) {
-  using Indices = make_index_sequence<std::tuple_size<Tuple>::value>;
+typename ApplyRes<F, typename std::decay<Tuple>::type>::type apply(F&& f,
+                                                                   Tuple&& t) {
+  using Indices = make_index_sequence<
+      std::tuple_size<typename std::decay<Tuple>::type>::value>;
   return ApplyImpl(std::forward<F>(f), std::forward<Tuple>(t), Indices());
 }
 

--- a/google/cloud/internal/tuple_test.cc
+++ b/google/cloud/internal/tuple_test.cc
@@ -57,6 +57,20 @@ TEST(ApplyTest, NoArgs) {
   EXPECT_EQ(42, i);
 }
 
+TEST(ApplyTest, TupleByReference) {
+  std::string s;
+  auto tuple = std::make_tuple("hello world");
+  auto res = ::google::cloud::internal::apply(
+      [&](std::string new_s) {
+        s = std::move(new_s);
+        return s.size();
+      },
+      tuple);
+  static_assert(std::is_same<decltype(res), std::size_t>::value, "");
+  EXPECT_EQ("hello world", s);
+  EXPECT_EQ(11, res);
+}
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud


### PR DESCRIPTION
`ApplyRes<>` used to try to match `std::tuple<>&` against `std::tuple<>`
and failed. This PR adds necessary `std::decay<>` to avoid it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/85)
<!-- Reviewable:end -->
