### PR TITLE
ci: update protobuf to-3.9.1

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -76,9 +76,9 @@ RUN pip install cmake_format==0.6.0
 # - When using CMake, only the version compiled with the same CMAKE_BUILD_TYPE
 #   as the dependent (gRPC or google-cloud-cpp) works.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-RUN tar -xf v3.6.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.6.1/cmake
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+RUN tar -xf v3.9.1.tar.gz
+WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
 RUN for build_type in "Debug" "Release"; do \
     cmake \
         -DCMAKE_BUILD_TYPE="${build_type}" \

--- a/super/external/protobuf.cmake
+++ b/super/external/protobuf.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET protobuf_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_PROTOBUF_URL
-        "https://github.com/google/protobuf/archive/v3.7.1.tar.gz")
+        "https://github.com/google/protobuf/archive/v3.9.1.tar.gz")
     set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
-        "f1748989842b46fa208b2a6e4e2785133cfcc3e4d43c17fecb023733f0f5443f")
+        "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357")
 
     set_external_project_build_parallel_level(PARALLEL)
 


### PR DESCRIPTION
I upgraded gRPC to 1.24.3, but missed a couple of places where we still
used protobuf-3.6.1. The newer gRPC requires the newer protobuf. This
was undetected by the builds because they fallback on the previously
cached docker image when creating the image fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/91)
<!-- Reviewable:end -->
