### PR TITLE
cleanup: remove *-dependencies target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,13 +122,6 @@ option(GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS
        "Enable building the gRPC utilities library." ON)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
 
-# There are a number of targets that are pure dependencies, i.e., do not contain
-# our own code. These targets can be skipped when using static analysis tools.
-# Can be built earlier in the CI environment (for example to warm up the cache).
-# And in general can receive special treatment. This custom target collects all
-# these special targets with a single name.
-add_custom_target(google-cloud-cpp-dependencies)
-
 # Enable testing in this directory so we can do a top-level `make test`. This
 # also includes the BUILD_TESTING option, which is on by default.
 include(CTest)

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -105,17 +105,6 @@ if [[ "${CREATE_GRAPHVIZ:-}" == "yes" ]]; then
       --build "${BINARY_DIR}"
 fi
 
-# If scan-build is enabled, we need to manually compile the dependencies;
-# otherwise, the static analyzer finds issues in them, and there is no way to
-# ignore them.  When scan-build is not enabled, this is still useful because
-# we can fold the output in Travis and make the log more interesting.
-echo "${COLOR_YELLOW}Started dependency build at: $(date)${COLOR_RESET}"
-echo
-cmake --build "${BINARY_DIR}" \
-    --target google-cloud-cpp-dependencies -- -j "${NCPU}"
-echo
-echo "${COLOR_YELLOW}Finished dependency build at: $(date)${COLOR_RESET}"
-
 # If scan-build is enabled we build the smallest subset of things that is
 # needed; otherwise, we pick errors from things we do not care about. With
 # scan-build disabled we compile everything, to test the build as most


### PR DESCRIPTION
The `google-cloud-cpp-dependencies` target is a remant from the days
when we automatically downloaded and compiled dependencies as part of
the top-level CMake file. We no longer do this, and therefore no longer
need the target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/92)
<!-- Reviewable:end -->
