### PR TITLE
ci: reduce layers in ci/kokoro/install Docker images

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -166,14 +166,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -184,15 +182,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -234,14 +229,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -252,15 +245,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -309,16 +299,16 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-tar -xf v3.9.1.tar.gz
-cd $HOME/Downloads/protobuf-3.9.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -329,11 +319,11 @@ distributes c-ares-1.9. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-tar -xf cares-1_14_0.tar.gz
-cd $HOME/Downloads/c-ares-cares-1_14_0
-./buildconf && ./configure && make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -344,11 +334,11 @@ Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-tar -xf v1.23.1.tar.gz
-cd $HOME/Downloads/grpc-1.23.1
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -358,14 +348,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -376,15 +364,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -420,16 +405,16 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-tar -xf v3.9.1.tar.gz
-cd $HOME/Downloads/protobuf-3.9.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -440,11 +425,11 @@ Cloud Platform proto files. We install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-tar -xf v1.23.1.tar.gz
-cd $HOME/Downloads/grpc-1.23.1
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -454,14 +439,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -472,15 +455,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -516,16 +496,16 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-tar -xf v3.9.1.tar.gz
-cd $HOME/Downloads/protobuf-3.9.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -536,11 +516,11 @@ distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-tar -xf cares-1_14_0.tar.gz
-cd $HOME/Downloads/c-ares-cares-1_14_0
-./buildconf && ./configure && make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -551,11 +531,11 @@ Cloud Platform proto files. We can install gRPC from source using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-tar -xf v1.23.1.tar.gz
-cd $HOME/Downloads/grpc-1.23.1
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -565,14 +545,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -583,15 +561,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -659,16 +634,16 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-tar -xf v3.9.1.tar.gz
-cd $HOME/Downloads/protobuf-3.9.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -679,11 +654,11 @@ distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-tar -xf cares-1_14_0.tar.gz
-cd $HOME/Downloads/c-ares-cares-1_14_0
-./buildconf && ./configure && make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -694,11 +669,11 @@ Cloud Platform proto files. We can install gRPC from source using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-tar -xf v1.23.1.tar.gz
-cd $HOME/Downloads/grpc-1.23.1
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -708,14 +683,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -726,15 +699,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -777,14 +747,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -795,15 +763,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -846,16 +811,16 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-tar -xf v3.9.1.tar.gz
-cd $HOME/Downloads/protobuf-3.9.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -866,11 +831,11 @@ Protobuf we just installed in `/usr/local`:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-tar -xf v1.23.1.tar.gz
-cd $HOME/Downloads/grpc-1.23.1
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -880,14 +845,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -898,15 +861,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -954,16 +914,16 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-tar -xf v3.9.1.tar.gz
-cd $HOME/Downloads/protobuf-3.9.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -974,11 +934,11 @@ Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-tar -xf v1.23.1.tar.gz
-cd $HOME/Downloads/grpc-1.23.1
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -988,14 +948,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1006,15 +964,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1068,16 +1023,16 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-tar -xf v3.9.1.tar.gz
-cd $HOME/Downloads/protobuf-3.9.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1088,11 +1043,11 @@ distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-tar -xf cares-1_14_0.tar.gz
-cd $HOME/Downloads/c-ares-cares-1_14_0
-./buildconf && ./configure && make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -1103,11 +1058,11 @@ Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-tar -xf v1.23.1.tar.gz
-cd $HOME/Downloads/grpc-1.23.1
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -1117,14 +1072,12 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1135,15 +1088,12 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-cmake --build cmake-out -- -j ${NCPU:-4}
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -58,17 +58,17 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### c-ares
@@ -78,12 +78,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-RUN tar -xf cares-1_14_0.tar.gz
-WORKDIR /var/tmp/build/c-ares-cares-1_14_0
-RUN ./buildconf && ./configure && make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -93,12 +93,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -107,15 +107,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -125,16 +123,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -52,17 +52,17 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -72,12 +72,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -86,15 +86,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -104,16 +102,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -47,15 +47,13 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -65,16 +63,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -47,17 +47,17 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -67,12 +67,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -81,15 +81,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -99,16 +97,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -48,15 +48,13 @@ RUN dnf makecache && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -66,16 +64,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -53,17 +53,17 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### c-ares
@@ -73,12 +73,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-RUN tar -xf cares-1_14_0.tar.gz
-WORKDIR /var/tmp/build/c-ares-cares-1_14_0
-RUN ./buildconf && ./configure && make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -88,12 +88,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -102,15 +102,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -120,16 +118,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -46,15 +46,13 @@ RUN zypper refresh && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -64,16 +62,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -40,17 +40,17 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -60,12 +60,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -74,15 +74,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -92,16 +90,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/install/Dockerfile.ubuntu-trusty
@@ -72,17 +72,17 @@ ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### c-ares
@@ -92,12 +92,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-RUN tar -xf cares-1_14_0.tar.gz
-WORKDIR /var/tmp/build/c-ares-cares-1_14_0
-RUN ./buildconf && ./configure && make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -107,12 +107,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -121,15 +121,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -139,16 +137,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -40,17 +40,17 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### c-ares
@@ -60,12 +60,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-RUN tar -xf cares-1_14_0.tar.gz
-WORKDIR /var/tmp/build/c-ares-cares-1_14_0
-RUN ./buildconf && ./configure && make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -75,12 +75,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -89,15 +89,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -107,16 +105,13 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/templates/kokoro/docker-fragments.sh
+++ b/ci/templates/kokoro/docker-fragments.sh
@@ -23,94 +23,89 @@ _EOF_
 
 read_into_variable INSTALL_CPP_CMAKEFILES_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 _EOF_
 
 read_into_variable INSTALL_GOOGLETEST_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 _EOF_
 
 read_into_variable INSTALL_CRC32C_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
-RUN tar -xf 1.0.6.tar.gz
-WORKDIR /var/tmp/build/crc32c-1.0.6
-RUN cmake \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=yes \
-      -DCRC32C_BUILD_TESTS=OFF \
-      -DCRC32C_BUILD_BENCHMARKS=OFF \
-      -DCRC32C_USE_GLOG=OFF \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz && \
+    tar -xf 1.0.6.tar.gz && \
+    cd crc32c-1.0.6 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DCRC32C_BUILD_TESTS=OFF \
+        -DCRC32C_BUILD_BENCHMARKS=OFF \
+        -DCRC32C_USE_GLOG=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 _EOF_
 
 read_into_variable INSTALL_PROTOBUF_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
+    tar -xf v3.9.1.tar.gz && \
+    cd protobuf-3.9.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 _EOF_
 
 read_into_variable INSTALL_C_ARES_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-RUN tar -xf cares-1_14_0.tar.gz
-WORKDIR /var/tmp/build/c-ares-cares-1_14_0
-RUN ./buildconf && ./configure && make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && ./configure && make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 _EOF_
 
 read_into_variable INSTALL_GRPC_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz
-RUN tar -xf v1.23.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.23.1
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
+    tar -xf v1.23.1.tar.gz && \
+    cd grpc-1.23.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 _EOF_
 
 read_into_variable INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz
-RUN tar -xf v0.13.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-0.13.0
-RUN cmake -H. -Bcmake-out \
-    -DBUILD_TESTING=OFF \
-    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz && \
+    tar -xf v0.13.0.tar.gz && \
+    cd google-cloud-cpp-common-0.13.0 && \
+    cmake -H. -Bcmake-out \
+        -DBUILD_TESTING=OFF \
+        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 _EOF_
 
 read_into_variable BUILD_PROJECT_CMAKE_SUPER_FRAGMENT <<'_EOF_'


### PR DESCRIPTION
Depending on how the server is configured the Docker images may have a
limit on the number of layers (about 120), and we are getting close to
this limit in some of our builds. Each `RUN` command creates a new
layer, so we can avoid creating too many by combining `RUN` and
`WORKDIR` commands using `&&`.

Note that `INSTALL.md` and  the files in `ci/kokoro/install` are automatically
generated.  Reviewing `ci/templates/*` may be less repetitive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/94)
<!-- Reviewable:end -->
