### PR TITLE
ci: more fixes for ci/kokoro/readme

### DIFF
--- a/ci/kokoro/readme/Dockerfile.centos-7
+++ b/ci/kokoro/readme/Dockerfile.centos-7
@@ -21,9 +21,6 @@
 ARG DISTRO_VERSION=7
 FROM centos:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the development tools and OpenSSL. The development tools distributed

--- a/ci/kokoro/readme/Dockerfile.centos-7
+++ b/ci/kokoro/readme/Dockerfile.centos-7
@@ -12,19 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=7
 FROM centos:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
 
 ## [START README.md]
 
-# First install the development tools and OpenSSL.
-# The development tools distributed with CentOS (notably CMake) are too old to
-# build `google-cloud-cpp-common`. In these instructions, we use `cmake3`
-# obtained from [Software Collections](https://www.softwarecollections.org/).
+# Install the development tools and OpenSSL. The development tools distributed
+# with CentOS (notably CMake) are too old to build the
+# `google-cloud-cpp-common` project. We recommend you install cmake3 from
+# [Software Collections](https://www.softwarecollections.org/).
 
 # ```bash
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
@@ -36,18 +41,13 @@ RUN yum makecache && \
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common
-# when using the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.centos-8
+++ b/ci/kokoro/readme/Dockerfile.centos-8
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=8
 FROM centos:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -29,18 +34,13 @@ RUN dnf makecache && \
         zlib-devel
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.centos-8
+++ b/ci/kokoro/readme/Dockerfile.centos-8
@@ -21,9 +21,6 @@
 ARG DISTRO_VERSION=8
 FROM centos:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the development tools needed to compile the project:

--- a/ci/kokoro/readme/Dockerfile.debian-buster
+++ b/ci/kokoro/readme/Dockerfile.debian-buster
@@ -21,9 +21,6 @@
 ARG DISTRO_VERSION=buster
 FROM debian:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # First install the development tools.

--- a/ci/kokoro/readme/Dockerfile.debian-buster
+++ b/ci/kokoro/readme/Dockerfile.debian-buster
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=buster
 FROM debian:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -30,18 +35,13 @@ RUN apt update && \
         pkg-config tar wget zlib1g-dev
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.debian-stretch
+++ b/ci/kokoro/readme/Dockerfile.debian-stretch
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=stretch
 FROM debian:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -30,18 +35,13 @@ RUN apt update && \
         pkg-config tar wget zlib1g-dev
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.debian-stretch
+++ b/ci/kokoro/readme/Dockerfile.debian-stretch
@@ -21,9 +21,6 @@
 ARG DISTRO_VERSION=stretch
 FROM debian:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # First install the development tools.

--- a/ci/kokoro/readme/Dockerfile.fedora
+++ b/ci/kokoro/readme/Dockerfile.fedora
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=30
 FROM fedora:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting below, it is used by `extract-readme.sh` and
 # `extract-install.md` to generate the contents of the top-level README.md and
@@ -30,18 +35,13 @@ RUN dnf makecache && \
         zlib-devel
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.fedora
+++ b/ci/kokoro/readme/Dockerfile.fedora
@@ -21,10 +21,6 @@
 ARG DISTRO_VERSION=30
 FROM fedora:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting below, it is used by `extract-readme.sh` and
-# `extract-install.md` to generate the contents of the top-level README.md and
-# INSTALL.md files.
-
 ## [START README.md]
 
 # Install the minimal development tools:

--- a/ci/kokoro/readme/Dockerfile.opensuse-leap
+++ b/ci/kokoro/readme/Dockerfile.opensuse-leap
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=latest
 FROM opensuse/leap:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 ## [START README.md]
 
@@ -26,18 +31,13 @@ RUN zypper refresh && \
         libcurl-devel libopenssl-devel make tar wget
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/readme/Dockerfile.opensuse-tumbleweed
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=latest
 FROM opensuse/tumbleweed:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 ## [START README.md]
 
@@ -26,18 +31,13 @@ RUN zypper refresh && \
         libcurl-devel libopenssl-devel make tar wget zlib-devel
 # ```
 
-FROM devtools AS README
+## [END README.md]
+
+FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-bionic
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=bionic
 FROM ubuntu:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -30,18 +35,13 @@ RUN apt update && \
         pkg-config tar wget zlib1g-dev
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-bionic
@@ -21,9 +21,6 @@
 ARG DISTRO_VERSION=bionic
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the minimal development tools:

--- a/ci/kokoro/readme/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-trusty
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=trusty
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
@@ -62,18 +68,13 @@ ENV OPENSSL_ROOT_DIR=/usr/local/ssl
 ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-trusty
@@ -22,10 +22,6 @@ ARG DISTRO_VERSION=trusty
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
 
-# Please keep the formatting below, it is used by `extract-readme.sh` and
-# `extract-install.md` to generate the contents of the top-level README.md and
-# INSTALL.md files.
-
 ## [START README.md]
 
 # Install the minimal development tools.

--- a/ci/kokoro/readme/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-xenial
@@ -21,9 +21,6 @@
 ARG DISTRO_VERSION=xenial
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the minimal development tools:

--- a/ci/kokoro/readme/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-xenial
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
+
 ARG DISTRO_VERSION=xenial
 FROM ubuntu:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -30,18 +35,13 @@ RUN apt update && \
         pkg-config tar wget zlib1g-dev
 # ```
 
+## [END README.md]
+
 FROM devtools AS readme
 ARG NCPU=4
 
-## [START IGNORED]
-# Verify that the tools above are enough to compile google-cloud-cpp-common when using
-# the super build.
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
-# The tests will already be run as part of the build, no need to run it again.
-## [END IGNORED]
-
-## [END README.md]
+RUN cmake --build cmake-out -- -j ${NCPU:-4}

--- a/ci/kokoro/readme/build.sh
+++ b/ci/kokoro/readme/build.sh
@@ -14,7 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-@WARNING_GENERATED_FILE_FRAGMENT@
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
 
 set -eu
 

--- a/ci/kokoro/readme/build.sh
+++ b/ci/kokoro/readme/build.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 set -eu
 
 if [[ $# -eq 1 ]]; then

--- a/ci/kokoro/readme/common.cfg
+++ b/ci/kokoro/readme/common.cfg
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-@WARNING_GENERATED_FILE_FRAGMENT@
+#
+# WARNING: This is an automatically generated file. Consider changing the
+#     sources instead. You can find the source templates and scripts at:
+#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#
 
 build_file: "google-cloud-cpp-common/ci/kokoro/readme/build.sh"
 timeout_mins: 120

--- a/ci/kokoro/readme/common.cfg
+++ b/ci/kokoro/readme/common.cfg
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 build_file: "google-cloud-cpp-common/ci/kokoro/readme/build.sh"
 timeout_mins: 120
 

--- a/ci/templates/generate-kokoro-readme.sh
+++ b/ci/templates/generate-kokoro-readme.sh
@@ -72,14 +72,17 @@ generate_dockerfile() {
 git -C "${DESTINATION_ROOT}" rm -fr --ignore-unmatch "ci/kokoro/readme"
 mkdir -p "${DESTINATION_ROOT}/ci/kokoro/readme"
 
-cp "${PROJECT_ROOT}/ci/templates/kokoro/readme/build.sh.in" \
-   "${DESTINATION_ROOT}/ci/kokoro/readme/build.sh"
+replace_fragments \
+    "WARNING_GENERATED_FILE_FRAGMENT" \
+    <"${PROJECT_ROOT}/ci/templates/kokoro/readme/build.sh.in" \
+    >"${DESTINATION_ROOT}/ci/kokoro/readme/build.sh"
 chmod 755 "${DESTINATION_ROOT}/ci/kokoro/readme/build.sh"
 git -C "${DESTINATION_ROOT}" add "ci/kokoro/readme/build.sh"
 
 replace_fragments \
-  < "${PROJECT_ROOT}/ci/templates/kokoro/readme/common.cfg.in" \
-  >"${DESTINATION_ROOT}/ci/kokoro/readme/common.cfg"
+    "WARNING_GENERATED_FILE_FRAGMENT" \
+    < "${PROJECT_ROOT}/ci/templates/kokoro/readme/common.cfg.in" \
+    >"${DESTINATION_ROOT}/ci/kokoro/readme/common.cfg"
 git -C "${DESTINATION_ROOT}" add "ci/kokoro/readme/common.cfg"
 
 for build in "${BUILD_NAMES[@]}"; do

--- a/ci/templates/kokoro/docker-fragments.sh
+++ b/ci/templates/kokoro/docker-fragments.sh
@@ -109,9 +109,12 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.
 _EOF_
 
 read_into_variable BUILD_PROJECT_CMAKE_SUPER_FRAGMENT <<'_EOF_'
+FROM devtools AS readme
+ARG NCPU=4
+
 WORKDIR /home/build/super
 COPY . /home/build/super
 RUN cmake -Hsuper -Bcmake-out \
         -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
-RUN cmake --build cmake-out -- -j ${NCPU}
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 _EOF_

--- a/ci/templates/kokoro/readme/Dockerfile.centos-7.in
+++ b/ci/templates/kokoro/readme/Dockerfile.centos-7.in
@@ -17,9 +17,6 @@
 ARG DISTRO_VERSION=7
 FROM centos:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the development tools and OpenSSL. The development tools distributed

--- a/ci/templates/kokoro/readme/Dockerfile.centos-7.in
+++ b/ci/templates/kokoro/readme/Dockerfile.centos-7.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=7
 FROM centos:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -37,7 +38,5 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/cte
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.centos-8.in
+++ b/ci/templates/kokoro/readme/Dockerfile.centos-8.in
@@ -17,9 +17,6 @@
 ARG DISTRO_VERSION=8
 FROM centos:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the development tools needed to compile the project:

--- a/ci/templates/kokoro/readme/Dockerfile.centos-8.in
+++ b/ci/templates/kokoro/readme/Dockerfile.centos-8.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=8
 FROM centos:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -30,7 +31,5 @@ RUN dnf makecache && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.debian-buster.in
+++ b/ci/templates/kokoro/readme/Dockerfile.debian-buster.in
@@ -17,9 +17,6 @@
 ARG DISTRO_VERSION=buster
 FROM debian:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # First install the development tools.

--- a/ci/templates/kokoro/readme/Dockerfile.debian-buster.in
+++ b/ci/templates/kokoro/readme/Dockerfile.debian-buster.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=buster
 FROM debian:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -31,7 +32,5 @@ RUN apt update && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.debian-stretch.in
+++ b/ci/templates/kokoro/readme/Dockerfile.debian-stretch.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=stretch
 FROM debian:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -31,7 +32,5 @@ RUN apt update && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.debian-stretch.in
+++ b/ci/templates/kokoro/readme/Dockerfile.debian-stretch.in
@@ -17,9 +17,6 @@
 ARG DISTRO_VERSION=stretch
 FROM debian:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # First install the development tools.

--- a/ci/templates/kokoro/readme/Dockerfile.fedora.in
+++ b/ci/templates/kokoro/readme/Dockerfile.fedora.in
@@ -17,10 +17,6 @@
 ARG DISTRO_VERSION=30
 FROM fedora:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting below, it is used by `extract-readme.sh` and
-# `extract-install.md` to generate the contents of the top-level README.md and
-# INSTALL.md files.
-
 ## [START README.md]
 
 # Install the minimal development tools:

--- a/ci/templates/kokoro/readme/Dockerfile.fedora.in
+++ b/ci/templates/kokoro/readme/Dockerfile.fedora.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=30
 FROM fedora:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting below, it is used by `extract-readme.sh` and
 # `extract-install.md` to generate the contents of the top-level README.md and
@@ -31,7 +32,5 @@ RUN dnf makecache && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.opensuse-leap.in
+++ b/ci/templates/kokoro/readme/Dockerfile.opensuse-leap.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=latest
 FROM opensuse/leap:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 ## [START README.md]
 
@@ -27,7 +28,5 @@ RUN zypper refresh && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.opensuse-tumbleweed.in
+++ b/ci/templates/kokoro/readme/Dockerfile.opensuse-tumbleweed.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=latest
 FROM opensuse/tumbleweed:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 ## [START README.md]
 
@@ -27,7 +28,5 @@ RUN zypper refresh && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.ubuntu-bionic.in
+++ b/ci/templates/kokoro/readme/Dockerfile.ubuntu-bionic.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=bionic
 FROM ubuntu:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -31,7 +32,5 @@ RUN apt update && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.ubuntu-bionic.in
+++ b/ci/templates/kokoro/readme/Dockerfile.ubuntu-bionic.in
@@ -17,9 +17,6 @@
 ARG DISTRO_VERSION=bionic
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the minimal development tools:

--- a/ci/templates/kokoro/readme/Dockerfile.ubuntu-trusty.in
+++ b/ci/templates/kokoro/readme/Dockerfile.ubuntu-trusty.in
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=trusty
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
@@ -63,7 +65,5 @@ ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.ubuntu-trusty.in
+++ b/ci/templates/kokoro/readme/Dockerfile.ubuntu-trusty.in
@@ -18,10 +18,6 @@ ARG DISTRO_VERSION=trusty
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 ARG NCPU=4
 
-# Please keep the formatting below, it is used by `extract-readme.sh` and
-# `extract-install.md` to generate the contents of the top-level README.md and
-# INSTALL.md files.
-
 ## [START README.md]
 
 # Install the minimal development tools.

--- a/ci/templates/kokoro/readme/Dockerfile.ubuntu-xenial.in
+++ b/ci/templates/kokoro/readme/Dockerfile.ubuntu-xenial.in
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+@WARNING_GENERATED_FILE_FRAGMENT@
+
 ARG DISTRO_VERSION=xenial
 FROM ubuntu:${DISTRO_VERSION} AS devtools
-ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -31,7 +32,5 @@ RUN apt update && \
 # ```
 
 ## [END README.md]
-
-FROM devtools AS readme
 
 @BUILD_PROJECT_CMAKE_SUPER_FRAGMENT@

--- a/ci/templates/kokoro/readme/Dockerfile.ubuntu-xenial.in
+++ b/ci/templates/kokoro/readme/Dockerfile.ubuntu-xenial.in
@@ -17,9 +17,6 @@
 ARG DISTRO_VERSION=xenial
 FROM ubuntu:${DISTRO_VERSION} AS devtools
 
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
-
 ## [START README.md]
 
 # Install the minimal development tools:


### PR DESCRIPTION
These are some final tweaks:

* Add the "automatically generated warnings"
* Refactor the `FROM devtools AS readme` line
* Place `ARG NCPU=...` in the right places

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/95)
<!-- Reviewable:end -->
