### PR TITLE
fix: placement of ARGs in install Dockerfiles

### DIFF
--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -47,6 +47,7 @@ BUILD_AND_TEST_PROJECT_FRAGMENT=$(replace_fragments \
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -133,6 +133,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -112,6 +112,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -73,6 +73,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -107,6 +107,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -74,6 +74,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -128,6 +128,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -72,6 +72,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -100,6 +100,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/install/Dockerfile.ubuntu-trusty
@@ -147,6 +147,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -115,6 +115,7 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # ```
 
 FROM devtools AS install
+ARG NCPU=4
 
 # #### Compile and install the main project
 


### PR DESCRIPTION
Whenever a `FROM` directive appears in a Dockerfile, all `ARG`s need to
be redeclared. Otherwise, they won't be propagated to the environment of
the executed commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/96)
<!-- Reviewable:end -->
