### PR TITLE
ci: configure copyright year for ci/kokoro/readme

### DIFF
--- a/ci/etc/kokoro/readme/project-config.sh
+++ b/ci/etc/kokoro/readme/project-config.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare -A ORIGINAL_COPYRIGHT_YEAR=(
+  [centos-7]=2019
+  [centos-8]=2019
+  [debian-buster]=2019
+  [debian-stretch]=2019
+  [fedora]=2019
+  [opensuse-leap]=2019
+  [opensuse-tumbleweed]=2019
+  [ubuntu-trusty]=2019
+  [ubuntu-xenial]=2019
+  [ubuntu-bionic]=2019
+)

--- a/ci/templates/generate-kokoro-readme.sh
+++ b/ci/templates/generate-kokoro-readme.sh
@@ -48,6 +48,8 @@ readonly BUILD_NAMES
 source "${PROJECT_ROOT}/ci/templates/kokoro/docker-fragments-functions.sh"
 # shellcheck source=../../ci/etc/kokoro/docker-fragments.sh
 source "${PROJECT_ROOT}/ci/templates/kokoro/docker-fragments.sh"
+# shellcheck source=../../ci/etc/kokoro/readme/project-config.sh
+source "${DESTINATION_ROOT}/ci/etc/kokoro/readme/project-config.sh"
 
 generate_dockerfile() {
   local -r build="$1"
@@ -64,7 +66,8 @@ generate_dockerfile() {
         "INSTALL_CRC32C_FROM_SOURCE" \
         "INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE" \
         "BUILD_PROJECT_CMAKE_SUPER_FRAGMENT" \
-    <"${PROJECT_ROOT}/ci/templates/kokoro/readme/Dockerfile.${build}.in" \
+    <"${PROJECT_ROOT}/ci/templates/kokoro/readme/Dockerfile.${build}.in" | \
+  sed -e "s/Copyright [0-9][0-9][0-9][0-9]/Copyright ${ORIGINAL_COPYRIGHT_YEAR[${build}]}/" \
     >"${target}"
 }
 


### PR DESCRIPTION
To generate the ci/kokoro/readme files in `google-cloud-cpp` we need the
copyright year to be configurable. No changes in the generated files for
this repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/98)
<!-- Reviewable:end -->
