### PR TITLE
ci: fix Docker image caching

### DIFF
--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -49,6 +49,13 @@ else
   exit 1
 fi
 
+echo "================================================================"
+echo "Load Google Container Registry configuration parameters $(date)."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
@@ -60,13 +67,6 @@ cd "${PROJECT_ROOT}"
 
 echo "================================================================"
 echo "Building with ${NCPU} cores $(date) on ${PWD}."
-
-echo "================================================================"
-echo "Load Google Container Registry configuration parameters $(date)."
-
-if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
-  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
-fi
 
 echo "================================================================"
 echo "Setup Google Container Registry access $(date)."

--- a/ci/kokoro/readme/build.sh
+++ b/ci/kokoro/readme/build.sh
@@ -50,6 +50,13 @@ else
   exit 1
 fi
 
+echo "================================================================"
+echo "Load Google Container Registry configuration parameters $(date)."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
@@ -61,13 +68,6 @@ cd "${PROJECT_ROOT}"
 
 echo "================================================================"
 echo "Building with ${NCPU} cores $(date) on ${PWD}."
-
-echo "================================================================"
-echo "Load Google Container Registry configuration parameters $(date)."
-
-if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
-  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
-fi
 
 echo "================================================================"
 echo "Setup Google Container Registry access $(date)."

--- a/ci/templates/kokoro/install/build.sh.in
+++ b/ci/templates/kokoro/install/build.sh.in
@@ -45,6 +45,13 @@ else
   exit 1
 fi
 
+echo "================================================================"
+echo "Load Google Container Registry configuration parameters $(date)."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
@@ -56,13 +63,6 @@ cd "${PROJECT_ROOT}"
 
 echo "================================================================"
 echo "Building with ${NCPU} cores $(date) on ${PWD}."
-
-echo "================================================================"
-echo "Load Google Container Registry configuration parameters $(date)."
-
-if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
-  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
-fi
 
 echo "================================================================"
 echo "Setup Google Container Registry access $(date)."

--- a/ci/templates/kokoro/readme/build.sh.in
+++ b/ci/templates/kokoro/readme/build.sh.in
@@ -46,6 +46,13 @@ else
   exit 1
 fi
 
+echo "================================================================"
+echo "Load Google Container Registry configuration parameters $(date)."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
@@ -57,13 +64,6 @@ cd "${PROJECT_ROOT}"
 
 echo "================================================================"
 echo "Building with ${NCPU} cores $(date) on ${PWD}."
-
-echo "================================================================"
-echo "Load Google Container Registry configuration parameters $(date)."
-
-if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
-  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
-fi
 
 echo "================================================================"
 echo "Setup Google Container Registry access $(date)."


### PR DESCRIPTION
We need to source the Google Container Registry (GCR) configuration
before defining the docker image names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/106)
<!-- Reviewable:end -->
