### PR TITLE
chore: remove sha256sum step from release process

### DIFF
--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -82,15 +82,6 @@ new "pre-release" at
 https://github.com/googleapis/google-cloud-cpp-common/releases. Add the release
 notes to the Release.
 
-After you create the release, capture the SHA256 checksums of the tarball and
-zip files, and edit the notes to include them. These commands might be handy:
-
-```bash
-TAG="<release-tag>" # change this to the actual tag, e.g., "v0.5.0"
-wget -q -O - "https://github.com/googleapis/google-cloud-cpp-common/archive/${TAG}.tar.gz" | sha256sum
-wget -q -O - "https://github.com/googleapis/google-cloud-cpp-common/archive/${TAG}.zip" | sha256sum
-```
-
 Ask your colleagues to review the release notes. There should be few/no edits
 needed at this point since the release notes were already reviewed in step 1.
 

--- a/release/release.sh
+++ b/release/release.sh
@@ -117,7 +117,6 @@ banner "Creating and pushing branch ${NEW_BRANCH}"
 run git checkout -b "${NEW_BRANCH}" "${NEW_TAG}"
 run git push --set-upstream origin "${NEW_BRANCH}"
 
-# Maybe todo: generate the tarball/zipball sha256 sums and add them to the body.
 # Maybe todo: extract the release notes from the README.md file and stick them
 #             in the release body.
 banner "Creating release"


### PR DESCRIPTION
Related to https://github.com/googleapis/google-cloud-cpp-spanner/issues/1187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/126)
<!-- Reviewable:end -->
