### PR TITLE
fix: crashes with non-empty CompletionQueue shutdown

### DIFF
--- a/google/cloud/grpc_utils/completion_queue.cc
+++ b/google/cloud/grpc_utils/completion_queue.cc
@@ -80,6 +80,8 @@ void CompletionQueue::Run() { impl_->Run(*this); }
 
 void CompletionQueue::Shutdown() { impl_->Shutdown(); }
 
+void CompletionQueue::CancelAll() { impl_->CancelAll(); }
+
 google::cloud::future<std::chrono::system_clock::time_point>
 CompletionQueue::MakeDeadlineTimer(
     std::chrono::system_clock::time_point deadline) {

--- a/google/cloud/grpc_utils/completion_queue.h
+++ b/google/cloud/grpc_utils/completion_queue.h
@@ -45,6 +45,9 @@ class CompletionQueue {
   /// Terminate the completion queue event loop.
   void Shutdown();
 
+  /// Cancel all pending operations.
+  void CancelAll();
+
   /**
    * Create a timer that fires at @p deadline.
    *

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.cc
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.cc
@@ -46,12 +46,15 @@ void CompletionQueueImpl::Run(CompletionQueue& cq) {
       ForgetOperation(tag);
     }
     std::unique_lock<std::mutex> lk(mu_);
-    if (shutdown_.load() && pending_ops_.empty()) break;
+    if (shutdown_ && pending_ops_.empty()) break;
   }
 }
 
 void CompletionQueueImpl::Shutdown() {
-  shutdown_.store(true);
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    shutdown_ = true;
+  }
   cq_.Shutdown();
 }
 

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.cc
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.cc
@@ -27,17 +27,16 @@ namespace grpc_utils {
 inline namespace GOOGLE_CLOUD_CPP_GRPC_UTILS_NS {
 namespace internal {
 void CompletionQueueImpl::Run(CompletionQueue& cq) {
-  while (!shutdown_.load()) {
-    void* tag;
-    bool ok;
-    auto deadline = std::chrono::system_clock::now() + kLoopTimeout;
-    auto status = cq_.AsyncNext(&tag, &ok, deadline);
-    if (status == grpc::CompletionQueue::SHUTDOWN) {
-      break;
-    }
-    if (status == grpc::CompletionQueue::TIMEOUT) {
-      continue;
-    }
+  void* tag;
+  bool ok;
+  auto deadline = [] {
+    return std::chrono::system_clock::now() + kLoopTimeout;
+  };
+
+  for (auto status = cq_.AsyncNext(&tag, &ok, deadline());
+       status != grpc::CompletionQueue::SHUTDOWN;
+       status = cq_.AsyncNext(&tag, &ok, deadline())) {
+    if (status == grpc::CompletionQueue::TIMEOUT) continue;
     if (status != grpc::CompletionQueue::GOT_EVENT) {
       google::cloud::internal::ThrowRuntimeError(
           "unexpected status from AsyncNext()");
@@ -46,12 +45,28 @@ void CompletionQueueImpl::Run(CompletionQueue& cq) {
     if (op->Notify(cq, ok)) {
       ForgetOperation(tag);
     }
+    std::unique_lock<std::mutex> lk(mu_);
+    if (shutdown_.load() && pending_ops_.empty()) break;
   }
 }
 
 void CompletionQueueImpl::Shutdown() {
   shutdown_.store(true);
   cq_.Shutdown();
+}
+
+void CompletionQueueImpl::CancelAll() {
+  // Cancel all operations. We need to make a copy of the operations because
+  // canceling them may trigger a recursive call that needs the lock. And we
+  // need the lock because canceling might trigger calls that invalidate the
+  // iterators.
+  auto pending = [this] {
+    std::unique_lock<std::mutex> lk(mu_);
+    return pending_ops_;
+  }();
+  for (auto& kv : pending) {
+    kv.second->Cancel();
+  }
 }
 
 std::unique_ptr<grpc::Alarm> CompletionQueueImpl::CreateAlarm() const {
@@ -131,10 +146,10 @@ void CompletionQueueImpl::SimulateCompletion(CompletionQueue& cq, bool ok) {
   grpc::CompletionQueue::NextStatus status;
   do {
     void* tag;
-    bool ok;
+    bool async_next_ok;
     auto deadline =
         std::chrono::system_clock::now() + std::chrono::milliseconds(1);
-    status = cq_.AsyncNext(&tag, &ok, deadline);
+    status = cq_.AsyncNext(&tag, &async_next_ok, deadline);
   } while (status == grpc::CompletionQueue::GOT_EVENT);
 }
 

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.h
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.h
@@ -246,6 +246,9 @@ class CompletionQueueImpl {
   /// Terminate the event loop.
   void Shutdown();
 
+  /// Cancel all existing operations.
+  void CancelAll();
+
   /// Create a new alarm object.
   virtual std::unique_ptr<grpc::Alarm> CreateAlarm() const;
 

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.h
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.h
@@ -284,8 +284,8 @@ class CompletionQueueImpl {
 
  private:
   grpc::CompletionQueue cq_;
-  std::atomic<bool> shutdown_;
   mutable std::mutex mu_;
+  bool shutdown_;
   std::unordered_map<std::intptr_t, std::shared_ptr<AsyncGrpcOperation>>
       pending_ops_;
 };


### PR DESCRIPTION
The underlying `grpc::CompletionQueue` requires draining all events
before it is safe to delete a completion queue. Therefore we need to
drain the queue before returning from `CompletionQueue::Run()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/127)
<!-- Reviewable:end -->
