### PR TITLE
chore: move release notes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,32 @@
 # Changelog
 
-### v0.18.x - TBD
+## v0.18.x - TBD
 
-### v0.17.x - 2019-12
+## v0.17.x - 2019-12
 
 * Cleanup and documentation changes only
 
-### v0.16.x - 2019-10
+## v0.16.x - 2019-10
 
 * fix: make `google::cloud::internal::apply` work for `std::tuple<>&`
 
-### v0.15.x - 2019-10
+## v0.15.x - 2019-10
 
 * chore: upgrade to gRPC-1.24.3 (#75)
 
-### v0.14.x - 2019-10
+## v0.14.x - 2019-10
 
 * feat: implement std::apply (#59)
 
-### v0.13.x - 2019-10
+## v0.13.x - 2019-10
 
 * feat: implement install components (#33)
 
-### v0.12.x - 2019-10
+## v0.12.x - 2019-10
 
 * bug: fix runtime install directory (#3063)
 
-### v0.11.x - 2019-09
+## v0.11.x - 2019-09
 
 * feat: Use macros for compiler id and version (#2937)
 * fix: Fix bazel build on windows. (#2940)
@@ -36,31 +36,31 @@
 * bug: fix builds with CMake 3.15 (#3033)
 * feat: Document behavior of passing empty string to SetEnv on Windows (#3030)
 
-### v0.10.x - 2019-08
+## v0.10.x - 2019-08
 
 * feat: add `conjunction` metafunction (#2892)
 * bug: Fix typo in testing_util/config.cmake.in (#2851)
 * bug: Include 'IncludeGMock.cmake' in testing_util/config.cmake.in (#2848)
 
-### v0.9.x - 2019-07
+## v0.9.x - 2019-07
 
 * feature: support `operator==` and `operator!=` for `StatusOr`.
 * feature: support assignment from `Status` in `StatusOr`.
 * feature: disable `optional<T>`'s converting constructor when
   `U == optional<T>`.
 
-### v0.7.x - 2019-05
+## v0.7.x - 2019-05
 
 * Support move-only callables in `future<T>`
 * Avoid `std::make_exception_ptr()` in `future_shared_state_base::abandon()`.
 
-### v0.6.x - 2019-04
+## v0.6.x - 2019-04
 
 * Avoid `std::make_exception_ptr()` when building without exceptions.
 * Removed the googleapis submodule. The build system now automatically
   downloads all deps.
 
-### v0.5.x - 2019-03
+## v0.5.x - 2019-03
 
 * **Breaking change**: Make `google::cloud::optional::operator bool()` explicit.
 * Add `google::cloud::optional` value conversions that match `std::optional`.
@@ -69,14 +69,14 @@
 * Change `std::endl` -> `"\n"`.
 * Enforce formatting of `.cc` files.
 
-### v0.4.x - 2019-02
+## v0.4.x - 2019-02
 
 * Fixed some documentation.
 * **Breaking change**: Removed `StatusOr<void>`.
 * Updated `StatusOr` documentation.
 * Fixed some (minor) issues found by coverity.
 
-### v0.3.x - 2019-01
+## v0.3.x - 2019-01
 
 * Support compiling with gcc-4.8.
 * Fix `GCP_LOG()` macro so it works on platforms that define a `DEBUG`
@@ -85,13 +85,13 @@
   clones of a backoff policy shared the same sequence.
 * Workaround build problems with Xcode 7.3.
 
-### v0.2.x - 2018-12
+## v0.2.x - 2018-12
 
 * Implement `google::cloud::future<T>` and `google::cloud::promise<T>` based on
   ISO/IEC TS 19571:2016, the "C++ Extensions for Concurrency" technical
   specification, also known as "futures with continuations".
 
-### v0.1.x - 2018-11
+## v0.1.x - 2018-11
 
 * `google::cloud::optional<T>` an intentionally incomplete implementation of
   `std::optional<T>` to support C++11 and C++14 users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,4 @@
-# Google Cloud C++ Client Libraries
-
-[![Documentation][doxygen-shield]][doxygen-link]
-
-[doxygen-shield]: https://img.shields.io/badge/documentation-master-brightgreen.svg
-[doxygen-link]: https://googleapis.dev/cpp/google-cloud-common/latest/
-
-This directory contains the following C++ client libraries:
-
-* [Cloud Bigtable](bigtable/README.md)
-* [Google Cloud Storage](storage/README.md)
-
-In addition some utilities shared across these libraries are also found here.
-Most of these utilities are in the `google::cloud::internal` namespace, and are
-not intended for direct use by consumers of the C++ client libraries.
-
-## Documentation
-
-Documentation for the common utilities is available [online][doxygen-link].
-
-## Release Notes
+# Changelog
 
 ### v0.18.x - TBD
 

--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -11,17 +11,14 @@ audience is expected to be familiar with the project itself, [git][git-docs],
 
 ## Preparing for a release
 
-First you should collect and update the release notes for the project. Prepare
-a pull request (PR) with the necessary changes to the README files in each
-project.
-
 Assuming you are working on your own fork of the `google-cloud-cpp-common`
 project, and `upstream` points to the `googleapis/google-cloud-cpp-common`
-remote, these commands should be useful in identifying important changes:
+remote, these commands should be useful in identifying important changes for
+inclusion in the release notes:
 
-### Update google/cloud/README.md
+### Update CHANGELOG.md
 
-Update `google/cloud/README.md` based on the release notes:
+Update `CHANGELOG.md` based on the release notes:
 
 ```bash
 git log --no-merges --format="format:* %s" \

--- a/release/release.sh
+++ b/release/release.sh
@@ -20,11 +20,11 @@
 #   3. Creates and pushes a new branch w/ the new version
 #   4. Creates the "Pre-Release" in the GitHub UI.
 #
-# Before running this script the user should make sure the README.md on master
-# is up-to-date with the release notes for the new release that will happen.
-# Then run this script. After running this script, the user must still go to
-# the GH UI where the new release will exist as a "pre-release", and edit the
-# release notes.
+# Before running this script the user should make sure the CHANGELOG.md on
+# master is up-to-date with the release notes for the new release that will
+# happen. Then run this script. After running this script, the user must still
+# go to the GH UI where the new release will exist as a "pre-release", and edit
+# the release notes.
 
 set -eu
 
@@ -117,8 +117,8 @@ banner "Creating and pushing branch ${NEW_BRANCH}"
 run git checkout -b "${NEW_BRANCH}" "${NEW_TAG}"
 run git push --set-upstream origin "${NEW_BRANCH}"
 
-# Maybe todo: extract the release notes from the README.md file and stick them
-#             in the release body.
+# Maybe todo: extract the release notes from the CHANGELOG.md file and stick
+#             them in the release body.
 banner "Creating release"
 run hub release create \
   --prerelease \


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/3334

Note also in this case, the release notes used to be inside the `google/cloud` directory. In this PR, I'm putting the release notes in a top-level `CHANGELOG.md` file, and I'm removing the google/cloud/README.md file, which seems to be unnecessary since we split "common" from google-cloud-cpp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/128)
<!-- Reviewable:end -->
