### PR TITLE
fix: remove the redundant conditions in the `Run()` loop

### DIFF
--- a/google/cloud/grpc_utils/internal/completion_queue_impl.cc
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.cc
@@ -45,18 +45,10 @@ void CompletionQueueImpl::Run(CompletionQueue& cq) {
     if (op->Notify(cq, ok)) {
       ForgetOperation(tag);
     }
-    std::unique_lock<std::mutex> lk(mu_);
-    if (shutdown_ && pending_ops_.empty()) break;
   }
 }
 
-void CompletionQueueImpl::Shutdown() {
-  {
-    std::lock_guard<std::mutex> lk(mu_);
-    shutdown_ = true;
-  }
-  cq_.Shutdown();
-}
+void CompletionQueueImpl::Shutdown() { cq_.Shutdown(); }
 
 void CompletionQueueImpl::CancelAll() {
   // Cancel all operations. We need to make a copy of the operations because

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.cc
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.cc
@@ -48,7 +48,13 @@ void CompletionQueueImpl::Run(CompletionQueue& cq) {
   }
 }
 
-void CompletionQueueImpl::Shutdown() { cq_.Shutdown(); }
+void CompletionQueueImpl::Shutdown() {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    shutdown_ = true;
+  }
+  cq_.Shutdown();
+}
 
 void CompletionQueueImpl::CancelAll() {
   // Cancel all operations. We need to make a copy of the operations because

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.h
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.h
@@ -231,7 +231,7 @@ using AsyncCallResponseType = AsyncCallResponseTypeUnwrap<
  */
 class CompletionQueueImpl {
  public:
-  CompletionQueueImpl() = default;
+  CompletionQueueImpl() : cq_(), shutdown_(false) {}
   virtual ~CompletionQueueImpl() = default;
 
   /**
@@ -284,6 +284,7 @@ class CompletionQueueImpl {
  private:
   grpc::CompletionQueue cq_;
   mutable std::mutex mu_;
+  bool shutdown_;  // GUARDED_BY(mu_)
   std::unordered_map<std::intptr_t, std::shared_ptr<AsyncGrpcOperation>>
       pending_ops_;  // GUARDED_BY(mu_)
 };

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.h
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.h
@@ -25,7 +25,6 @@
 #include <grpcpp/alarm.h>
 #include <grpcpp/support/async_stream.h>
 #include <grpcpp/support/async_unary_call.h>
-#include <atomic>
 #include <string>
 #include <unordered_map>
 
@@ -232,7 +231,7 @@ using AsyncCallResponseType = AsyncCallResponseTypeUnwrap<
  */
 class CompletionQueueImpl {
  public:
-  CompletionQueueImpl() : cq_(), shutdown_(false) {}
+  CompletionQueueImpl() = default;
   virtual ~CompletionQueueImpl() = default;
 
   /**
@@ -285,9 +284,8 @@ class CompletionQueueImpl {
  private:
   grpc::CompletionQueue cq_;
   mutable std::mutex mu_;
-  bool shutdown_;
   std::unordered_map<std::intptr_t, std::shared_ptr<AsyncGrpcOperation>>
-      pending_ops_;
+      pending_ops_;  // GUARDED_BY(mu_)
 };
 
 }  // namespace internal


### PR DESCRIPTION
`shutdown_ && pending_ops_.empty()` will be true exactly when the next call to `AsyncNext()` will return `SHUTDOWN`, so we should just rely on the latter without checking the former.

(we could possibly `assert(shutdown_ && pending_ops_.empty())` at the end of the loop but it didn't seem worthwhile).

part of #129

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/131)
<!-- Reviewable:end -->
