### PR TITLE
fix: CompletionQueue rejects operations after shutdown

### DIFF
--- a/google/cloud/grpc_utils/completion_queue.cc
+++ b/google/cloud/grpc_utils/completion_queue.cc
@@ -86,8 +86,10 @@ google::cloud::future<std::chrono::system_clock::time_point>
 CompletionQueue::MakeDeadlineTimer(
     std::chrono::system_clock::time_point deadline) {
   auto op = std::make_shared<AsyncTimerFuture>(impl_->CreateAlarm());
-  void* tag = impl_->RegisterOperation(op);
-  op->Set(impl_->cq(), deadline, tag);
+  void* tag = impl_->RegisterOperation(*this, op);
+  if (tag != nullptr) {
+    op->Set(impl_->cq(), deadline, tag);
+  }
   return op->GetFuture();
 }
 

--- a/google/cloud/grpc_utils/completion_queue.h
+++ b/google/cloud/grpc_utils/completion_queue.h
@@ -111,8 +111,10 @@ class CompletionQueue {
       std::unique_ptr<grpc::ClientContext> context) {
     auto op =
         std::make_shared<internal::AsyncUnaryRpcFuture<Request, Response>>();
-    void* tag = impl_->RegisterOperation(op);
-    op->Start(async_call, std::move(context), request, &impl_->cq(), tag);
+    void* tag = impl_->RegisterOperation(*this, op);
+    if (tag != nullptr) {
+      op->Start(async_call, std::move(context), request, &impl_->cq(), tag);
+    }
     return op->GetFuture();
   }
 

--- a/google/cloud/grpc_utils/internal/async_read_stream_impl.h
+++ b/google/cloud/grpc_utils/internal/async_read_stream_impl.h
@@ -157,8 +157,10 @@ class AsyncReadStreamImpl
     cq_ = std::move(cq);
     reader_ = async_call(context_.get(), request, &cq_->cq());
     auto callback = std::make_shared<NotifyStart>(this->shared_from_this());
-    void* tag = cq_->RegisterOperation(std::move(callback));
-    reader_->StartCall(tag);
+    void* tag = cq_->RegisterOperation(*this, std::move(callback));
+    if (tag != nullptr) {
+      reader_->StartCall(tag);
+    }
   }
 
   /// Cancel the current streaming read RPC.
@@ -195,8 +197,10 @@ class AsyncReadStreamImpl
 
     auto callback = std::make_shared<NotifyRead>(this->shared_from_this());
     auto response = &callback->response;
-    void* tag = cq_->RegisterOperation(std::move(callback));
-    reader_->Read(response, tag);
+    void* tag = cq_->RegisterOperation(*this, std::move(callback));
+    if (tag != nullptr) {
+      reader_->Read(response, tag);
+    }
   }
 
   /// Handle the result of a `Read()` call.
@@ -243,8 +247,10 @@ class AsyncReadStreamImpl
 
     auto callback = std::make_shared<NotifyFinish>(this->shared_from_this());
     auto status = &callback->status;
-    void* tag = cq_->RegisterOperation(std::move(callback));
-    reader_->Finish(status, tag);
+    void* tag = cq_->RegisterOperation(*this, std::move(callback));
+    if (tag != nullptr) {
+      reader_->Finish(status, tag);
+    }
   }
 
   /// Handle the result of a Finish() request.
@@ -278,8 +284,10 @@ class AsyncReadStreamImpl
 
     auto callback = std::make_shared<NotifyDiscard>(this->shared_from_this());
     auto response = &callback->response;
-    void* tag = cq_->RegisterOperation(std::move(callback));
-    reader_->Read(response, tag);
+    void* tag = cq_->RegisterOperation(*this, std::move(callback));
+    if (tag != nullptr) {
+      reader_->Read(response, tag);
+    }
   }
 
   /// Handle the result of a Discard() call.

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.h
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.h
@@ -256,7 +256,8 @@ class CompletionQueueImpl {
   grpc::CompletionQueue& cq() { return cq_; }
 
   /// Add a new asynchronous operation to the completion queue.
-  void* RegisterOperation(std::shared_ptr<AsyncGrpcOperation> op);
+  void* RegisterOperation(CompletionQueue& cq,
+                          std::shared_ptr<AsyncGrpcOperation> op);
 
  protected:
   /// Return the asynchronous operation associated with @p tag.


### PR DESCRIPTION
Once the CompletionQueue is shutdown we need to drain existing
operations, but also should stop accepting them, or applications have no
way to shutdown cleanly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/132)
<!-- Reviewable:end -->
