### PR TITLE
feat!: change the result type for timers to StatusOr

### DIFF
--- a/google/cloud/grpc_utils/completion_queue.h
+++ b/google/cloud/grpc_utils/completion_queue.h
@@ -54,8 +54,10 @@ class CompletionQueue {
    * @param deadline when should the timer expire.
    *
    * @return a future that becomes satisfied after @p deadline.
+   * The result of the future is the time at which it expired, or an error
+   * Status if the timer did not run to expiration(e.g. it was Cancelled).
    */
-  google::cloud::future<std::chrono::system_clock::time_point>
+  google::cloud::future<StatusOr<std::chrono::system_clock::time_point>>
   MakeDeadlineTimer(std::chrono::system_clock::time_point deadline);
 
   /**
@@ -75,9 +77,11 @@ class CompletionQueue {
    * @param duration when should the timer expire relative to the current time.
    *
    * @return a future that becomes satisfied after @p duration time has elapsed.
+   * The result of the future is the time at which it expired, or an error
+   * Status if the timer did not run to expiration(e.g. it was Cancelled).
    */
   template <typename Rep, typename Period>
-  future<std::chrono::system_clock::time_point> MakeRelativeTimer(
+  future<StatusOr<std::chrono::system_clock::time_point>> MakeRelativeTimer(
       std::chrono::duration<Rep, Period> duration) {
     return MakeDeadlineTimer(std::chrono::system_clock::now() + duration);
   }
@@ -175,7 +179,10 @@ class CompletionQueue {
                 internal::CheckRunAsyncCallback<Functor>::value, int>::type = 0>
   void RunAsync(Functor&& functor) {
     MakeRelativeTimer(std::chrono::seconds(0))
-        .then([this, functor](future<std::chrono::system_clock::time_point>) {
+        .then([this, functor](
+                  future<StatusOr<std::chrono::system_clock::time_point>>) {
+          // We intentionally ignore the status here; the functor is always
+          // called, even after a call to `CancelAll`.
           CompletionQueue cq(impl_);
           functor(cq);
         });

--- a/google/cloud/grpc_utils/completion_queue.h
+++ b/google/cloud/grpc_utils/completion_queue.h
@@ -54,8 +54,8 @@ class CompletionQueue {
    * @param deadline when should the timer expire.
    *
    * @return a future that becomes satisfied after @p deadline.
-   * The result of the future is the time at which it expired, or an error
-   * Status if the timer did not run to expiration(e.g. it was Cancelled).
+   *     The result of the future is the time at which it expired, or an error
+   *     Status if the timer did not run to expiration (e.g. it was cancelled).
    */
   google::cloud::future<StatusOr<std::chrono::system_clock::time_point>>
   MakeDeadlineTimer(std::chrono::system_clock::time_point deadline);
@@ -77,8 +77,8 @@ class CompletionQueue {
    * @param duration when should the timer expire relative to the current time.
    *
    * @return a future that becomes satisfied after @p duration time has elapsed.
-   * The result of the future is the time at which it expired, or an error
-   * Status if the timer did not run to expiration(e.g. it was Cancelled).
+   *     The result of the future is the time at which it expired, or an error
+   *     Status if the timer did not run to expiration (e.g. it was cancelled).
    */
   template <typename Rep, typename Period>
   future<StatusOr<std::chrono::system_clock::time_point>> MakeRelativeTimer(

--- a/google/cloud/grpc_utils/completion_queue_test.cc
+++ b/google/cloud/grpc_utils/completion_queue_test.cc
@@ -73,7 +73,6 @@ TEST(CompletionQueueTest, ShutdownWithPending) {
   using ms = std::chrono::milliseconds;
 
   future<void> timer;
-  future<void> timer2;
   {
     CompletionQueue cq;
     std::thread runner([&cq] { cq.Run(); });

--- a/google/cloud/grpc_utils/completion_queue_test.cc
+++ b/google/cloud/grpc_utils/completion_queue_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/grpc_utils/completion_queue.h"
 #include "google/cloud/future.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gtest/gtest.h>
 #include <chrono>
 #include <memory>
@@ -38,7 +39,8 @@ TEST(CompletionQueueTest, TimerSmokeTest) {
   using ms = std::chrono::milliseconds;
   promise<void> wait_for_sleep;
   cq.MakeRelativeTimer(ms(2))
-      .then([&wait_for_sleep](future<std::chrono::system_clock::time_point>) {
+      .then([&wait_for_sleep](
+                future<StatusOr<std::chrono::system_clock::time_point>>) {
         wait_for_sleep.set_value();
       })
       .get();
@@ -56,7 +58,8 @@ TEST(CompletionQueueTest, MockSmokeTest) {
   using ms = std::chrono::milliseconds;
   promise<void> wait_for_sleep;
   cq.MakeRelativeTimer(ms(20000)).then(
-      [&wait_for_sleep](future<std::chrono::system_clock::time_point>) {
+      [&wait_for_sleep](
+          future<StatusOr<std::chrono::system_clock::time_point>>) {
         wait_for_sleep.set_value();
       });
   mock->SimulateCompletion(cq, true);
@@ -70,11 +73,15 @@ TEST(CompletionQueueTest, ShutdownWithPending) {
   using ms = std::chrono::milliseconds;
 
   future<void> timer;
+  future<void> timer2;
   {
     CompletionQueue cq;
     std::thread runner([&cq] { cq.Run(); });
     timer = cq.MakeRelativeTimer(ms(20)).then(
-        [](future<std::chrono::system_clock::time_point>) {});
+        [](future<StatusOr<std::chrono::system_clock::time_point>> result) {
+          // Timer still runs to completion after `Shutdown`.
+          EXPECT_STATUS_OK(result.get().status());
+        });
     EXPECT_EQ(std::future_status::timeout, timer.wait_for(ms(0)));
     cq.Shutdown();
     EXPECT_EQ(std::future_status::timeout, timer.wait_for(ms(0)));
@@ -92,9 +99,13 @@ TEST(CompletionQueueTest, CanCancelAllEvents) {
     cq.Run();
     done.set_value();
   });
-  cq.MakeRelativeTimer(ms(20000));
-  cq.MakeRelativeTimer(ms(20000));
-  cq.MakeRelativeTimer(ms(20000));
+  for (int i = 0; i < 3; ++i) {
+    cq.MakeRelativeTimer(ms(20000)).then(
+        [](future<StatusOr<std::chrono::system_clock::time_point>> result) {
+          // Cancelled timers return CANCELLED status.
+          EXPECT_EQ(StatusCode::kCancelled, result.get().status().code());
+        });
+  }
   auto f = done.get_future();
   EXPECT_EQ(std::future_status::timeout, f.wait_for(ms(1)));
   cq.Shutdown();


### PR DESCRIPTION
The result of the `future` returned from `MakeDeadlineTimer` and
`MakeRelativeTimer` is now a `StatusOr` that indicates whether the
timer ran to expiration or not (e.g. it was Cancelled).

BREAKING CHANGE: Most callers of `MakeDeadlineTimer` or `MakeRelativeTimer` will need to be updated.

Part of #129

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/134)
<!-- Reviewable:end -->
