### PR TITLE
chore: remove `CompletionQueue` parameter to `AsyncGrpcOperation::Notify`

### DIFF
--- a/google/cloud/grpc_utils/completion_queue.cc
+++ b/google/cloud/grpc_utils/completion_queue.cc
@@ -61,7 +61,7 @@ class AsyncTimerFuture : public internal::AsyncGrpcOperation {
   }
 
  private:
-  bool Notify(CompletionQueue&, bool ok) override {
+  bool Notify(bool ok) override {
     if (!ok) {
       promise_.set_value(Status(StatusCode::kCancelled, "timer canceled"));
     } else {
@@ -80,7 +80,7 @@ class AsyncTimerFuture : public internal::AsyncGrpcOperation {
 
 CompletionQueue::CompletionQueue() : impl_(new internal::CompletionQueueImpl) {}
 
-void CompletionQueue::Run() { impl_->Run(*this); }
+void CompletionQueue::Run() { impl_->Run(); }
 
 void CompletionQueue::Shutdown() { impl_->Shutdown(); }
 

--- a/google/cloud/grpc_utils/completion_queue_test.cc
+++ b/google/cloud/grpc_utils/completion_queue_test.cc
@@ -62,7 +62,7 @@ TEST(CompletionQueueTest, MockSmokeTest) {
           future<StatusOr<std::chrono::system_clock::time_point>>) {
         wait_for_sleep.set_value();
       });
-  mock->SimulateCompletion(cq, true);
+  mock->SimulateCompletion(/*ok=*/true);
 
   auto f = wait_for_sleep.get_future();
   EXPECT_EQ(std::future_status::ready, f.wait_for(ms(0)));

--- a/google/cloud/grpc_utils/internal/async_read_stream_impl.h
+++ b/google/cloud/grpc_utils/internal/async_read_stream_impl.h
@@ -146,7 +146,7 @@ class AsyncReadStreamImpl
 
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
-      bool Notify(CompletionQueue&, bool ok) override {
+      bool Notify(bool ok) override {
         control_->OnStart(ok);
         return true;
       }
@@ -186,7 +186,7 @@ class AsyncReadStreamImpl
 
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
-      bool Notify(CompletionQueue&, bool ok) override {
+      bool Notify(bool ok) override {
         control_->OnRead(ok, std::move(response));
         return true;
       }
@@ -234,7 +234,7 @@ class AsyncReadStreamImpl
 
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
-      bool Notify(CompletionQueue&, bool ok) override {
+      bool Notify(bool ok) override {
         control_->OnFinish(ok, grpc_utils::MakeStatusFromRpcError(status));
         return true;
       }
@@ -269,7 +269,7 @@ class AsyncReadStreamImpl
 
      private:
       void Cancel() override {}  // LCOV_EXCL_LINE
-      bool Notify(CompletionQueue&, bool ok) override {
+      bool Notify(bool ok) override {
         control_->OnDiscard(ok, std::move(response));
         return true;
       }

--- a/google/cloud/grpc_utils/internal/completion_queue_impl.cc
+++ b/google/cloud/grpc_utils/internal/completion_queue_impl.cc
@@ -26,7 +26,7 @@ namespace cloud {
 namespace grpc_utils {
 inline namespace GOOGLE_CLOUD_CPP_GRPC_UTILS_NS {
 namespace internal {
-void CompletionQueueImpl::Run(CompletionQueue& cq) {
+void CompletionQueueImpl::Run() {
   void* tag;
   bool ok;
   auto deadline = [] {
@@ -42,7 +42,7 @@ void CompletionQueueImpl::Run(CompletionQueue& cq) {
           "unexpected status from AsyncNext()");
     }
     auto op = FindOperation(tag);
-    if (op->Notify(cq, ok)) {
+    if (op->Notify(ok)) {
       ForgetOperation(tag);
     }
   }
@@ -116,16 +116,15 @@ void CompletionQueueImpl::ForgetOperation(void* tag) {
 // `CompletionQueueImpl`, wrap it in a `CompletionQueue` and call this function
 // to simulate the operation lifecycle. Note that the unit test must simulate
 // the operation results separately.
-void CompletionQueueImpl::SimulateCompletion(CompletionQueue& cq,
-                                             AsyncOperation* op, bool ok) {
+void CompletionQueueImpl::SimulateCompletion(AsyncOperation* op, bool ok) {
   auto internal_op = FindOperation(op);
   internal_op->Cancel();
-  if (internal_op->Notify(cq, ok)) {
+  if (internal_op->Notify(ok)) {
     ForgetOperation(op);
   }
 }
 
-void CompletionQueueImpl::SimulateCompletion(CompletionQueue& cq, bool ok) {
+void CompletionQueueImpl::SimulateCompletion(bool ok) {
   // Make a copy to avoid race conditions or iterator invalidation.
   std::vector<void*> tags;
   {
@@ -138,7 +137,7 @@ void CompletionQueueImpl::SimulateCompletion(CompletionQueue& cq, bool ok) {
   for (void* tag : tags) {
     auto internal_op = FindOperation(tag);
     internal_op->Cancel();
-    if (internal_op->Notify(cq, ok)) {
+    if (internal_op->Notify(ok)) {
       ForgetOperation(tag);
     }
   }


### PR DESCRIPTION
This parameter was unused, so remove it.
Also remove `CompletionQueue` from `Run()` and `SimulateCompletion()` which
only passed it through to `Notify()`.

Part of #129

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/136)
<!-- Reviewable:end -->
