### PR TITLE
fix: make test not flaky

### DIFF
--- a/google/cloud/grpc_utils/completion_queue_test.cc
+++ b/google/cloud/grpc_utils/completion_queue_test.cc
@@ -268,7 +268,6 @@ TEST(CompletionQueueTest, MakeStreamingReadRpc) {
 }
 
 TEST(CompletionQueueTest, RunAsync) {
-  using ms = std::chrono::milliseconds;
   CompletionQueue cq;
 
   std::thread runner([&cq] { cq.Run(); });
@@ -277,7 +276,6 @@ TEST(CompletionQueueTest, RunAsync) {
   cq.RunAsync([&done_promise](CompletionQueue&) { done_promise.set_value(); });
 
   auto done = done_promise.get_future();
-  EXPECT_EQ(std::future_status::ready, done.wait_for(ms(10)));
   done.get();
 
   cq.Shutdown();


### PR DESCRIPTION
No need to wait for X milliseconds on the future. We are going to block
on the same future later on the test, that is really what we want to
verify, that the function is called "eventually".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/143)
<!-- Reviewable:end -->
