### PR TITLE
ci: use gRPC-1.26.x to workaround a known bug

### DIFF
--- a/bazel/google_cloud_cpp_common_deps.bzl
+++ b/bazel/google_cloud_cpp_common_deps.bzl
@@ -65,12 +65,11 @@ def google_cloud_cpp_common_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.26.0",
+            strip_prefix = "grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.26.0.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.26.0.tar.gz",
+                "https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz",
             ],
-            sha256 = "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81",
+            sha256 = "a2034a1c8127e35c0cc7b86c1b5ad6d8e79a62c5e133c379b8b22a78ba370015",
         )
 
     # We use the cc_proto_library() rule from @com_google_protobuf, which

--- a/super/external/grpc.cmake
+++ b/super/external/grpc.cmake
@@ -23,9 +23,10 @@ if (NOT TARGET grpc-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.26.0.tar.gz")
+        "https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz"
+    )
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81")
+        "a2034a1c8127e35c0cc7b86c1b5ad6d8e79a62c5e133c379b8b22a78ba370015")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
Workaround grpc/grpc#21280 by compiling against a specific commit
(without a tag) of the v1.26.x gRPC branch.

This fixes #145 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/146)
<!-- Reviewable:end -->
