### PR TITLE
fix: avoid/quash some shellcheck warnings

### DIFF
--- a/ci/templates/generate-kokoro-install.sh
+++ b/ci/templates/generate-kokoro-install.sh
@@ -49,11 +49,11 @@ BUILD_NAMES=(
 )
 readonly BUILD_NAMES
 
-# shellcheck source=../../ci/etc/kokoro/docker-fragments.sh
+# shellcheck disable=SC1091
 source "${PROJECT_ROOT}/ci/templates/kokoro/docker-fragments-functions.sh"
-# shellcheck source=../ci/../etc/kokoro/docker-fragments.sh
+# shellcheck disable=SC1091
 source "${PROJECT_ROOT}/ci/templates/kokoro/docker-fragments.sh"
-# shellcheck source=../../ci/etc/kokoro/install/project-config.sh
+# shellcheck disable=SC1091
 source "${DESTINATION_ROOT}/ci/etc/kokoro/install/project-config.sh"
 
 generate_dockerfile() {

--- a/ci/templates/generate-kokoro-readme.sh
+++ b/ci/templates/generate-kokoro-readme.sh
@@ -49,11 +49,11 @@ BUILD_NAMES=(
 )
 readonly BUILD_NAMES
 
-# shellcheck source=../../ci/etc/kokoro/docker-fragments.sh
+# shellcheck disable=SC1091
 source "${PROJECT_ROOT}/ci/templates/kokoro/docker-fragments-functions.sh"
-# shellcheck source=../../ci/etc/kokoro/docker-fragments.sh
+# shellcheck disable=SC1091
 source "${PROJECT_ROOT}/ci/templates/kokoro/docker-fragments.sh"
-# shellcheck source=../../ci/etc/kokoro/readme/project-config.sh
+# shellcheck disable=SC1091
 source "${DESTINATION_ROOT}/ci/etc/kokoro/readme/project-config.sh"
 
 generate_dockerfile() {

--- a/ci/templates/kokoro/docker-fragments-functions.sh
+++ b/ci/templates/kokoro/docker-fragments-functions.sh
@@ -28,6 +28,7 @@ replace_fragments() {
 
   local sed_args=()
   for fragment in "${fragment_names[@]}"; do
+    # shellcheck disable=SC2016
     sed_args+=("-e" "s,@${fragment}@,$(/bin/echo -n "${!fragment}" |
         # Note the use of \003 ("End of Text") as the magic character to
         # represent newlines. This must match the invert `tr` call below. It

--- a/ci/test-readme/generate-readme.sh
+++ b/ci/test-readme/generate-readme.sh
@@ -41,7 +41,7 @@ Google Cloud C++ Client Libraries.
 
 _EOF_
 
-${BINDIR}/../generate-badges.sh
+"${BINDIR}/../generate-badges.sh"
 
 cat <<'_EOF_'
 ## Table of Contents


### PR DESCRIPTION
SC1091: Disable if we don't statically know the source path.
SC2016: `shellcheck` thinks the `` `/\\` `` is a command substitution.
SC2086: Double quote ${BINDIR} expansion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/148)
<!-- Reviewable:end -->
