### PR TITLE
ci: use gRPC-1.26.x to workaround a known bug

### DIFF
--- a/ci/templates/kokoro/docker-fragments.sh
+++ b/ci/templates/kokoro/docker-fragments.sh
@@ -102,9 +102,9 @@ _EOF_
 
 read_into_variable INSTALL_GRPC_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
-    tar -xf v1.23.1.tar.gz && \
-    cd grpc-1.23.1 && \
+RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig


### PR DESCRIPTION
Workaround grpc/grpc#21280 by compiling against a specific commit
(without a tag) of the v1.26.x gRPC branch.

This extends #146 to allow the change to be imported into upstream
repos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/150)
<!-- Reviewable:end -->
