### PR TITLE
ci: use protobuf-3.11.3 in the builds and docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -298,9 +298,9 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -404,9 +404,9 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -495,9 +495,9 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -672,9 +672,9 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -775,9 +775,9 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -884,9 +884,9 @@ Google Cloud Platform proto files:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ The libraries also depend on gRPC, libcurl, and the dependencies of those
 libraries. The Google Cloud C++ Client libraries are tested with the following
 versions of these dependencies:
 
-| Library | Minimum version |
-| ------- | --------------- |
-| gRPC    | v1.16.x |
-| libcurl | 7.47.0  |
+| Library  | Minimum version |
+| -------- | --------------- |
+| protobuf | v3.11.3 |
+| gRPC     | v1.26.x |
+| libcurl  | 7.47.0  |
 
 #### Tests
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,10 +33,6 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
-# Call the workspace dependency functions defined, but not invoked, in grpc_deps.bzl.
-load("@upb//bazel:workspace_deps.bzl", "upb_deps")
-upb_deps()
-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-apple_rules_dependencies()
-load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-apple_support_dependencies()
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()

--- a/bazel/google_cloud_cpp_common_deps.bzl
+++ b/bazel/google_cloud_cpp_common_deps.bzl
@@ -60,6 +60,16 @@ def google_cloud_cpp_common_deps():
             build_file = "@com_github_googleapis_google_cloud_cpp_common//bazel:googleapis.BUILD",
         )
 
+    if "com_google_protobuf" not in native.existing_rules():
+        http_archive(
+            name = "com_google_protobuf",
+            strip_prefix = "protobuf-3.11.3",
+            urls = [
+                "https://github.com/google/protobuf/archive/v3.11.3.tar.gz",
+            ],
+            sha256 = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
+        )
+
     # Load gRPC and its dependencies, using a similar pattern to this function.
     # This implicitly loads "com_google_protobuf", which we use.
     if "com_github_grpc_grpc" not in native.existing_rules():

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -76,9 +76,9 @@ RUN pip install cmake_format==0.6.0
 # - When using CMake, only the version compiled with the same CMAKE_BUILD_TYPE
 #   as the dependent (gRPC or google-cloud-cpp) works.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
-RUN tar -xf v3.9.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz
+RUN tar -xf v3.11.3.tar.gz
+WORKDIR /var/tmp/build/protobuf-3.11.3/cmake
 RUN for build_type in "Debug" "Release"; do \
     cmake \
         -DCMAKE_BUILD_TYPE="${build_type}" \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -58,9 +58,9 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -52,9 +52,9 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -47,9 +47,9 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -53,9 +53,9 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -40,9 +40,9 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -40,9 +40,9 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/ci/templates/kokoro/docker-fragments.sh
+++ b/ci/templates/kokoro/docker-fragments.sh
@@ -77,9 +77,9 @@ _EOF_
 
 read_into_variable INSTALL_PROTOBUF_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
-    tar -xf v3.9.1.tar.gz && \
-    cd protobuf-3.9.1/cmake && \
+RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \

--- a/ci/test-readme/generate-readme.sh
+++ b/ci/test-readme/generate-readme.sh
@@ -99,10 +99,11 @@ The libraries also depend on gRPC, libcurl, and the dependencies of those
 libraries. The Google Cloud C++ Client libraries are tested with the following
 versions of these dependencies:
 
-| Library | Minimum version |
-| ------- | --------------- |
-| gRPC    | v1.16.x |
-| libcurl | 7.47.0  |
+| Library  | Minimum version |
+| -------- | --------------- |
+| protobuf | v3.11.3 |
+| gRPC     | v1.26.x |
+| libcurl  | 7.47.0  |
 
 #### Tests
 

--- a/super/external/protobuf.cmake
+++ b/super/external/protobuf.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET protobuf-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_PROTOBUF_URL
-        "https://github.com/google/protobuf/archive/v3.9.1.tar.gz")
+        "https://github.com/google/protobuf/archive/v3.11.3.tar.gz")
     set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
-        "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357")
+        "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
We need protobuf-3.11.3 to successfully compile the latest and greatest
protos on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/151)
<!-- Reviewable:end -->
