### PR TITLE
refactor: copy TracingOptions from spanner

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -169,6 +169,8 @@ add_library(
     status_or.h
     terminate_handler.cc
     terminate_handler.h
+    tracing_options.h
+    tracing_options.cc
     version.cc
     version.h)
 target_link_libraries(
@@ -230,7 +232,8 @@ if (BUILD_TESTING)
         optional_test.cc
         status_or_test.cc
         status_test.cc
-        terminate_handler_test.cc)
+        terminate_handler_test.cc
+        tracing_options_test.cc)
 
     # Export the list of unit tests so the Bazel BUILD file can pick it up.
     export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -54,6 +54,7 @@ google_cloud_cpp_common_hdrs = [
     "status.h",
     "status_or.h",
     "terminate_handler.h",
+    "tracing_options.h",
     "version.h",
 ]
 
@@ -73,5 +74,6 @@ google_cloud_cpp_common_srcs = [
     "log.cc",
     "status.cc",
     "terminate_handler.cc",
+    "tracing_options.cc",
     "version.cc",
 ]

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -41,4 +41,5 @@ google_cloud_cpp_common_unit_tests = [
     "status_or_test.cc",
     "status_test.cc",
     "terminate_handler_test.cc",
+    "tracing_options_test.cc",
 ]

--- a/google/cloud/tracing_options.cc
+++ b/google/cloud/tracing_options.cc
@@ -1,0 +1,68 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/tracing_options.h"
+#include "google/cloud/optional.h"
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
+optional<bool> ParseBoolean(std::string const& str) {
+  for (const auto t : {"Y", "y", "T", "t", "1", "on"}) {
+    if (str == t) return true;
+  }
+  for (const auto f : {"N", "n", "F", "f", "0", "off"}) {
+    if (str == f) return false;
+  }
+  return {};
+}
+
+optional<std::int64_t> ParseInteger(std::string const& str) {
+  std::size_t econv = -1;
+  auto val = std::stoll(str, &econv);
+  if (econv != str.size()) return {};
+  return val;
+}
+
+}  // namespace
+
+TracingOptions& TracingOptions::SetOptions(std::string const& str) {
+  auto const beg = str.begin();
+  auto const end = str.end();
+  for (auto pos = beg;;) {
+    auto const comma = std::find(pos, end, ',');
+    auto const equal = std::find(pos, comma, '=');
+    std::string const opt{pos, equal};
+    std::string const val{equal + (equal == comma ? 0 : 1), comma};
+    if (opt == "single_line_mode") {
+      if (auto v = ParseBoolean(val)) single_line_mode_ = *v;
+    } else if (opt == "use_short_repeated_primitives") {
+      if (auto v = ParseBoolean(val)) use_short_repeated_primitives_ = *v;
+    } else if (opt == "truncate_string_field_longer_than") {
+      if (auto v = ParseInteger(val)) truncate_string_field_longer_than_ = *v;
+    }
+    if (comma == end) break;
+    pos = comma + 1;
+  }
+  return *this;
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/tracing_options.h
+++ b/google/cloud/tracing_options.h
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TRACING_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TRACING_OPTIONS_H
+
+#include "google/cloud/version.h"
+#include <cstdint>
+#include <string>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+/**
+ * The configuration parameters for RPC/protobuf tracing.
+ *
+ * The default options are:
+ *   single_line_mode=on
+ *   use_short_repeated_primitives=on
+ *   truncate_string_field_longer_than=128
+ */
+class TracingOptions {
+ public:
+  /// Override the default options with values from @p `str`.
+  TracingOptions& SetOptions(std::string const& str);
+
+  /// The entire message will be output on a single line with no line breaks.
+  bool single_line_mode() const { return single_line_mode_; }
+
+  /// Print repeated primitives in a compact format instead of each value on
+  /// its own line.
+  bool use_short_repeated_primitives() const {
+    return use_short_repeated_primitives_;
+  }
+
+  /// If non-zero, truncate all string/bytes fields longer than this.
+  std::int64_t truncate_string_field_longer_than() const {
+    return truncate_string_field_longer_than_;
+  }
+
+ private:
+  bool single_line_mode_ = true;
+  bool use_short_repeated_primitives_ = true;
+  std::int64_t truncate_string_field_longer_than_ = 128;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TRACING_OPTIONS_H

--- a/google/cloud/tracing_options_test.cc
+++ b/google/cloud/tracing_options_test.cc
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/tracing_options.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
+TEST(TracingOptionsTest, Defaults) {
+  TracingOptions tracing_options;
+  EXPECT_TRUE(tracing_options.single_line_mode());
+  EXPECT_TRUE(tracing_options.use_short_repeated_primitives());
+  EXPECT_EQ(128, tracing_options.truncate_string_field_longer_than());
+
+  // Unknown/unparseable options are ignored.
+  tracing_options.SetOptions("foo=1,bar=T,baz=no");
+  EXPECT_TRUE(tracing_options.single_line_mode());
+  EXPECT_TRUE(tracing_options.use_short_repeated_primitives());
+  EXPECT_EQ(128, tracing_options.truncate_string_field_longer_than());
+}
+
+TEST(TracingOptionsTest, Override) {
+  TracingOptions tracing_options;
+  tracing_options.SetOptions(
+      ",single_line_mode=F"
+      ",use_short_repeated_primitives=n"
+      ",truncate_string_field_longer_than=256");
+  EXPECT_FALSE(tracing_options.single_line_mode());
+  EXPECT_FALSE(tracing_options.use_short_repeated_primitives());
+  EXPECT_EQ(256, tracing_options.truncate_string_field_longer_than());
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Copy the `TracingOptions` class from `google-cloud-cpp-spanner`. I need
them in `google-cloud-cpp-pubsub`, and it seems terrible to just copy
the code. The plan is to first copy the classes here (so we can start
using them in `g-c-cpp-pubsub`) and then create aliases in
`g-c-cpp-spanner` that point to the classes in this repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/161)
<!-- Reviewable:end -->
