### PR TITLE
refactor: copy ConnectionOptions from spanner

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -319,6 +319,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
         background_threads.h
         completion_queue.cc
         completion_queue.h
+        connection_options.cc
+        connection_options.h
         grpc_error_delegate.cc
         grpc_error_delegate.h
         grpc_utils/async_operation.h
@@ -355,7 +357,9 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
         # List the unit tests, then setup the targets and dependencies.
         set(google_cloud_cpp_grpc_utils_unit_tests
             # cmake-format: sort
-            completion_queue_test.cc grpc_error_delegate_test.cc
+            completion_queue_test.cc
+            connection_options_test.cc
+            grpc_error_delegate_test.cc
             internal/background_threads_impl_test.cc)
 
         # Export the list of unit tests so the Bazel BUILD file can pick it up.

--- a/google/cloud/connection_options.cc
+++ b/google/cloud/connection_options.cc
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/connection_options.h"
+#include "google/cloud/log.h"
+#include <sstream>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+std::set<std::string> DefaultTracingComponents() {
+  auto tracing =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+  if (!tracing.has_value()) return {};
+  std::set<std::string> result;
+  std::istringstream is{*tracing};
+  std::string token;
+  while (std::getline(is, token, ',')) {
+    result.insert(token);
+  }
+  return result;
+}
+
+TracingOptions DefaultTracingOptions() {
+  auto tracing_options =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_TRACING_OPTIONS");
+  if (!tracing_options) return {};
+  return TracingOptions{}.SetOptions(*tracing_options);
+}
+
+void DefaultLogging() {
+  if (google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG")
+          .has_value()) {
+    google::cloud::LogSink::EnableStdClog();
+  }
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/connection_options.cc
+++ b/google/cloud/connection_options.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/connection_options.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/log.h"
 #include <sstream>
 
@@ -45,6 +47,11 @@ void DefaultLogging() {
           .has_value()) {
     google::cloud::LogSink::EnableStdClog();
   }
+}
+
+std::unique_ptr<BackgroundThreads> DefaultBackgroundThreads() {
+  return google::cloud::internal::make_unique<
+      AutomaticallyCreatedBackgroundThreads>();
 }
 
 }  // namespace internal

--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -21,7 +21,6 @@
 #include "google/cloud/tracing_options.h"
 #include <grpcpp/grpcpp.h>
 #include <functional>
-#include <map>
 #include <memory>
 #include <set>
 #include <string>

--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -15,10 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONNECTION_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONNECTION_OPTIONS_H
 
-#include "google/cloud/background_threads.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/internal/background_threads_impl.h"
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
 #include <grpcpp/grpcpp.h>
@@ -34,6 +32,7 @@ namespace internal {
 std::set<std::string> DefaultTracingComponents();
 TracingOptions DefaultTracingOptions();
 void DefaultLogging();
+std::unique_ptr<BackgroundThreads> DefaultBackgroundThreads();
 }  // namespace internal
 
 /**
@@ -54,10 +53,7 @@ class ConnectionOptions {
         tracing_components_(internal::DefaultTracingComponents()),
         tracing_options_(internal::DefaultTracingOptions()),
         user_agent_prefix_(ConnectionTraits::user_agent_prefix()),
-        background_threads_factory_([] {
-          return google::cloud::internal::make_unique<
-              internal::AutomaticallyCreatedBackgroundThreads>();
-        }) {
+        background_threads_factory_(internal::DefaultBackgroundThreads) {
     internal::DefaultLogging();
   }
 

--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -1,0 +1,247 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONNECTION_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONNECTION_OPTIONS_H
+
+#include "google/cloud/background_threads.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/internal/background_threads_impl.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/tracing_options.h"
+#include <grpcpp/grpcpp.h>
+#include <functional>
+#include <memory>
+#include <set>
+#include <string>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+std::set<std::string> DefaultTracingComponents();
+TracingOptions DefaultTracingOptions();
+void DefaultLogging();
+}  // namespace internal
+
+/**
+ * The configuration parameters for spanner connections.
+ */
+template <typename ConnectionTraits>
+class ConnectionOptions {
+ public:
+  /// The default options, using `grpc::GoogleDefaultCredentials()`.
+  ConnectionOptions() : ConnectionOptions(grpc::GoogleDefaultCredentials()) {}
+
+  /// Default parameters, using an explicit credentials object.
+  explicit ConnectionOptions(
+      std::shared_ptr<grpc::ChannelCredentials> credentials)
+      : credentials_(std::move(credentials)),
+        endpoint_(ConnectionTraits::default_endpoint()),
+        num_channels_(ConnectionTraits::default_num_channels()),
+        tracing_components_(internal::DefaultTracingComponents()),
+        tracing_options_(internal::DefaultTracingOptions()),
+        user_agent_prefix_(ConnectionTraits::user_agent_prefix()),
+        background_threads_factory_([] {
+          return google::cloud::internal::make_unique<
+              internal::AutomaticallyCreatedBackgroundThreads>();
+        }) {
+    internal::DefaultLogging();
+  }
+
+  /// Change the gRPC credentials from the default of
+  /// `grpc::GoogleDefaultCredentials()`.
+  ConnectionOptions& set_credentials(
+      std::shared_ptr<grpc::ChannelCredentials> v) {
+    credentials_ = std::move(v);
+    return *this;
+  }
+
+  /// The gRPC credentials used by clients configured with this object.
+  std::shared_ptr<grpc::ChannelCredentials> credentials() const {
+    return credentials_;
+  }
+
+  /**
+   * Change the gRPC endpoint used to contact the Cloud Spanner service.
+   *
+   * In almost all cases the default ("spanner.googleapis.com") is the correct
+   * endpoint to use. It may need to be changed to (1) test against a fake or
+   * simulator, or (2) to use a beta or EAP version of the service.
+   */
+  ConnectionOptions& set_endpoint(std::string v) {
+    endpoint_ = std::move(v);
+    return *this;
+  }
+
+  /// The endpoint used by clients configured with this object.
+  std::string const& endpoint() const { return endpoint_; }
+
+  /**
+   * The number of transport channels to create.
+   *
+   * Some transports limit the number of simultaneous calls in progress on a
+   * channel (for gRPC the limit is 100). Increasing the number of channels
+   * thus increases the number of operations that can be in progress in
+   * parallel.
+   *
+   * The default value is 4.
+   */
+  int num_channels() const { return num_channels_; }
+
+  /// Set the value for `num_channels()`.
+  ConnectionOptions& set_num_channels(int num_channels) {
+    num_channels_ = num_channels;
+    return *this;
+  }
+
+  /**
+   * Return whether tracing is enabled for the given @p component.
+   *
+   * The Cloud Spanner C++ client can log interesting events to help library and
+   * application developers troubleshoot problems with the library or their
+   * configuration. This flag returns true if tracing should be enabled by
+   * clients configured with this option.
+   *
+   * Currently only the `rpc` component is supported, which enables logging of
+   * each RPC, including its parameters and any responses.
+   */
+  bool tracing_enabled(std::string const& component) const {
+    return tracing_components_.find(component) != tracing_components_.end();
+  }
+
+  /// Enable tracing for @p component in clients configured with this object.
+  ConnectionOptions& enable_tracing(std::string const& component) {
+    tracing_components_.insert(component);
+    return *this;
+  }
+
+  /// Disable tracing for @p component in clients configured with this object.
+  ConnectionOptions& disable_tracing(std::string const& component) {
+    tracing_components_.erase(component);
+    return *this;
+  }
+
+  /// Return the options for use when tracing RPCs.
+  TracingOptions tracing_options() const { return tracing_options_; }
+
+  /**
+   * Define the gRPC channel domain for clients configured with this object.
+   *
+   * In some cases applications may want to use a separate gRPC connections for
+   * different clients. gRPC may share the connection used by separate channels
+   * created with the same configuration. The client objects created with this
+   * object will create gRPC channels configured with
+   * `grpc.channel_pooling_domain` set to the value returned by
+   * `channel_pool_domain()`. gRPC channels with different values for
+   * `grpc.channel_pooling_domain` are guaranteed to use different connections.
+   * Note that there is no guarantee that channels with the same value will have
+   * the same connection though.
+   *
+   * This option might be useful for applications that want to segregate traffic
+   * for whatever reason.
+   */
+  std::string const& channel_pool_domain() const {
+    return channel_pool_domain_;
+  }
+
+  /// Set the value for `channel_pool_domain()`.
+  ConnectionOptions& set_channel_pool_domain(std::string v) {
+    channel_pool_domain_ = std::move(v);
+    return *this;
+  }
+
+  /**
+   * Prepend @p prefix to the user-agent string.
+   *
+   * Libraries or services that use the Cloud Spanner C++ client may want to
+   * set their own user-agent prefix. This can help them develop telemetry
+   * information about number of users running particular versions of their
+   * system or library.
+   */
+  ConnectionOptions& add_user_agent_prefix(std::string prefix) {
+    prefix += " ";
+    prefix += user_agent_prefix_;
+    user_agent_prefix_ = std::move(prefix);
+    return *this;
+  }
+
+  /// Return the current value for the user agent string.
+  std::string const& user_agent_prefix() const { return user_agent_prefix_; }
+
+  /**
+   * Create a new `grpc::ChannelArguments` configured with the options in this
+   * object.
+   *
+   * The caller would typically pass this argument to
+   * `grpc::CreateCustomChannel` and create one more more gRPC channels.
+   */
+  grpc::ChannelArguments CreateChannelArguments() const {
+    grpc::ChannelArguments channel_arguments;
+
+    if (!channel_pool_domain().empty()) {
+      // To get a different channel pool one just needs to set any channel
+      // parameter to a different value. Newer versions of gRPC include a macro
+      // for this purpose (GRPC_ARG_CHANNEL_POOL_DOMAIN). As we are compiling
+      // against older versions in some cases, we use the actual value.
+      channel_arguments.SetString("grpc.channel_pooling_domain",
+                                  channel_pool_domain());
+    }
+    channel_arguments.SetUserAgentPrefix(user_agent_prefix());
+    return channel_arguments;
+  }
+
+  /**
+   * Configure the connection to use @p cq for all background work.
+   *
+   * Connections need to perform background work on behalf of the application.
+   * Normally they just create a background thread and a `CompletionQueue` for
+   * this work, but the application may need more fine-grained control of their
+   * threads. In this case the application can provide the `CompletionQueue` and
+   * it assumes responsibility for creating one or more threads blocked on
+   * `CompletionQueue::Run()`.
+   */
+  ConnectionOptions& DisableBackgroundThreads(
+      google::cloud::CompletionQueue const& cq) {
+    background_threads_factory_ = [cq] {
+      return google::cloud::internal::make_unique<
+          internal::CustomerSuppliedBackgroundThreads>(cq);
+    };
+    return *this;
+  }
+
+  using BackgroundThreadsFactory =
+      std::function<std::unique_ptr<BackgroundThreads>()>;
+  BackgroundThreadsFactory background_threads_factory() const {
+    return background_threads_factory_;
+  }
+
+ private:
+  std::shared_ptr<grpc::ChannelCredentials> credentials_;
+  std::string endpoint_;
+  int num_channels_;
+  std::set<std::string> tracing_components_;
+  TracingOptions tracing_options_;
+  std::string channel_pool_domain_;
+
+  std::string user_agent_prefix_;
+  BackgroundThreadsFactory background_threads_factory_;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_CONNECTION_OPTIONS_H

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -217,7 +217,7 @@ TEST(ConnectionOptionsTest, DefaultTracingOptionsNoEnvironment) {
   EXPECT_EQ(expected.use_short_repeated_primitives(),
             actual.use_short_repeated_primitives());
   EXPECT_EQ(expected.truncate_string_field_longer_than(),
-            expected.truncate_string_field_longer_than());
+            actual.truncate_string_field_longer_than());
 }
 
 TEST(ConnectionOptionsTest, DefaultTracingOptionsWithValue) {

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -1,0 +1,257 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/connection_options.h"
+#include "google/cloud/internal/compiler_info.h"
+#include "google/cloud/internal/setenv.h"
+#include "google/cloud/log.h"
+#include "google/cloud/testing_util/environment_variable_restore.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
+using ::google::cloud::testing_util::EnvironmentVariableRestore;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::StartsWith;
+
+/// Use these traits to test ConnectionOptions.
+struct TestTraits {
+  static std::string default_endpoint() { return "test-endpoint.example.com"; }
+  static std::string user_agent_prefix() { return "test-prefix"; }
+  static int default_num_channels() { return 7; }
+};
+
+using TestConnectionOptions = ConnectionOptions<TestTraits>;
+
+TEST(ConnectionOptionsTest, Credentials) {
+  // In the CI environment grpc::GoogleDefaultCredentials() may assert. Use the
+  // insecure credentials to initialize the options in any unit test.
+  auto expected = grpc::InsecureChannelCredentials();
+  TestConnectionOptions options(expected);
+  EXPECT_EQ(expected.get(), options.credentials().get());
+
+  auto other_credentials = grpc::InsecureChannelCredentials();
+  EXPECT_NE(expected, other_credentials);
+  options.set_credentials(other_credentials);
+  EXPECT_EQ(other_credentials, options.credentials());
+}
+
+TEST(ConnectionOptionsTest, AdminEndpoint) {
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  EXPECT_EQ(TestTraits::default_endpoint(), options.endpoint());
+  options.set_endpoint("invalid-endpoint");
+  EXPECT_EQ("invalid-endpoint", options.endpoint());
+}
+
+TEST(ConnectionOptionsTest, NumChannels) {
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  int num_channels = options.num_channels();
+  EXPECT_EQ(TestTraits::default_num_channels(), num_channels);
+  num_channels *= 2;  // ensure we change it from the default value.
+  options.set_num_channels(num_channels);
+  EXPECT_EQ(num_channels, options.num_channels());
+}
+
+TEST(ConnectionOptionsTest, Tracing) {
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  options.enable_tracing("fake-component");
+  EXPECT_TRUE(options.tracing_enabled("fake-component"));
+  options.disable_tracing("fake-component");
+  EXPECT_FALSE(options.tracing_enabled("fake-component"));
+}
+
+TEST(ConnectionOptionsTest, DefaultTracingUnset) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+
+  google::cloud::internal::UnsetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  EXPECT_FALSE(options.tracing_enabled("rpc"));
+}
+
+TEST(ConnectionOptionsTest, DefaultTracingSet) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+
+  google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING",
+                                  "foo,bar,baz");
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  EXPECT_FALSE(options.tracing_enabled("rpc"));
+  EXPECT_TRUE(options.tracing_enabled("foo"));
+  EXPECT_TRUE(options.tracing_enabled("bar"));
+  EXPECT_TRUE(options.tracing_enabled("baz"));
+}
+
+TEST(ConnectionOptionsTest, TracingOptions) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_TRACING_OPTIONS");
+
+  google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_TRACING_OPTIONS",
+                                  ",single_line_mode=off"
+                                  ",use_short_repeated_primitives=off"
+                                  ",truncate_string_field_longer_than=32");
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  TracingOptions tracing_options = options.tracing_options();
+  EXPECT_FALSE(tracing_options.single_line_mode());
+  EXPECT_FALSE(tracing_options.use_short_repeated_primitives());
+  EXPECT_EQ(32, tracing_options.truncate_string_field_longer_than());
+}
+
+TEST(ConnectionOptionsTest, ChannelPoolName) {
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  EXPECT_TRUE(options.channel_pool_domain().empty());
+  options.set_channel_pool_domain("test-channel-pool");
+  EXPECT_EQ("test-channel-pool", options.channel_pool_domain());
+}
+
+TEST(ConnectionOptionsTest, UserAgentPrefix) {
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  EXPECT_EQ(TestTraits::user_agent_prefix(), options.user_agent_prefix());
+  options.add_user_agent_prefix("test-prefix/1.2.3");
+  EXPECT_EQ("test-prefix/1.2.3 " + TestTraits::user_agent_prefix(),
+            options.user_agent_prefix());
+}
+
+TEST(ConnectionOptionsTest, CreateChannelArgumentsDefault) {
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+
+  auto actual = options.CreateChannelArguments();
+
+  // Use the low-level C API because grpc::ChannelArguments lacks high-level
+  // accessors.
+  grpc_channel_args test_args = actual.c_channel_args();
+  ASSERT_EQ(1, test_args.num_args);
+  ASSERT_EQ(GRPC_ARG_STRING, test_args.args[0].type);
+  EXPECT_EQ("grpc.primary_user_agent", std::string(test_args.args[0].key));
+  // The gRPC library adds its own version to the user-agent string, so we only
+  // check that our component appears in it.
+  EXPECT_THAT(std::string(test_args.args[0].value.string),
+              StartsWith(options.user_agent_prefix()));
+}
+
+TEST(ConnectionOptionsTest, CreateChannelArgumentsWithChannelPool) {
+  TestConnectionOptions options(grpc::InsecureChannelCredentials());
+  options.set_channel_pool_domain("testing-pool");
+  options.add_user_agent_prefix("test-prefix/1.2.3");
+
+  auto actual = options.CreateChannelArguments();
+
+  // Use the low-level C API because grpc::ChannelArguments lacks high-level
+  // accessors.
+  grpc_channel_args test_args = actual.c_channel_args();
+  ASSERT_EQ(2, test_args.num_args);
+  ASSERT_EQ(GRPC_ARG_STRING, test_args.args[0].type);
+  ASSERT_EQ(GRPC_ARG_STRING, test_args.args[1].type);
+
+  // There is no (AFAICT) guarantee on the order of the arguments in this array,
+  // and the C types are hard to work with. Capture the arguments in a map to
+  // make it easier to work with them.
+  std::map<std::string, std::string> args;
+  for (std::size_t i = 0; i != test_args.num_args; ++i) {
+    args[test_args.args[i].key] = test_args.args[i].value.string;
+  }
+
+  EXPECT_EQ("testing-pool", args["grpc.channel_pooling_domain"]);
+  // The gRPC library adds its own version to the user-agent string, so we only
+  // check that our component appears in it.
+  EXPECT_THAT(args["grpc.primary_user_agent"],
+              StartsWith(options.user_agent_prefix()));
+}
+
+TEST(ConnectionOptionsTest, CustomBackgroundThreads) {
+  CompletionQueue cq;
+
+  auto options = TestConnectionOptions(grpc::InsecureChannelCredentials())
+                     .DisableBackgroundThreads(cq);
+  auto background = options.background_threads_factory()();
+
+  using ms = std::chrono::milliseconds;
+
+  // Schedule some work, it cannot execute because there is no thread attached.
+  auto background_thread_id = background->cq().MakeRelativeTimer(ms(0)).then(
+      [](future<StatusOr<std::chrono::system_clock::time_point>>) {
+        return std::this_thread::get_id();
+      });
+  EXPECT_NE(std::future_status::ready, background_thread_id.wait_for(ms(1)));
+
+  // Verify we can create our own threads to drain the completion queue.
+  std::thread t([&cq] { cq.Run(); });
+  EXPECT_EQ(std::future_status::ready, background_thread_id.wait_for(ms(100)));
+
+  cq.Shutdown();
+  t.join();
+}
+
+TEST(ConnectionOptionsTest, DefaultTracingComponentsNoEnvironment) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+  internal::UnsetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+  auto const actual = internal::DefaultTracingComponents();
+  EXPECT_THAT(actual, ElementsAre());
+}
+
+TEST(ConnectionOptionsTest, DefaultTracingComponentsWithValue) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+  internal::SetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING", "a,b,c");
+  auto const actual = internal::DefaultTracingComponents();
+  EXPECT_THAT(actual, ElementsAre("a", "b", "c"));
+}
+
+TEST(ConnectionOptionsTest, DefaultTracingOptionsNoEnvironment) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_TRACING_OPTIONS");
+  internal::UnsetEnv("GOOGLE_CLOUD_CPP_TRACING_OPTIONS");
+  auto const actual = internal::DefaultTracingOptions();
+  auto const expected = TracingOptions{};
+  EXPECT_EQ(expected.single_line_mode(), actual.single_line_mode());
+  EXPECT_EQ(expected.use_short_repeated_primitives(),
+            actual.use_short_repeated_primitives());
+  EXPECT_EQ(expected.truncate_string_field_longer_than(),
+            expected.truncate_string_field_longer_than());
+}
+
+TEST(ConnectionOptionsTest, DefaultTracingOptionsWithValue) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_TRACING_OPTIONS");
+  internal::SetEnv("GOOGLE_CLOUD_CPP_TRACING_OPTIONS",
+                   "single_line_mode=on"
+                   ",use_short_repeated_primitives=ON"
+                   ",truncate_string_field_longer_than=42");
+  auto const actual = internal::DefaultTracingOptions();
+  EXPECT_TRUE(actual.single_line_mode());
+  EXPECT_TRUE(actual.use_short_repeated_primitives());
+  EXPECT_EQ(42, actual.truncate_string_field_longer_than());
+}
+
+TEST(ConnectionOptionsTest, DefaultLoggingNoEnvironment) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_CLOG");
+  LogSink::Instance().ClearBackends();
+  internal::UnsetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG");
+  internal::DefaultLogging();
+  EXPECT_EQ(0, LogSink::Instance().BackendCount());
+}
+
+TEST(ConnectionOptionsTest, DefaultLoggingWithValue) {
+  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_CLOG");
+  LogSink::Instance().ClearBackends();
+  EXPECT_EQ(0, LogSink::Instance().BackendCount());
+  internal::SetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG", "any-value");
+  internal::DefaultLogging();
+  EXPECT_EQ(1, LogSink::Instance().BackendCount());
+  LogSink::DisableStdClog();
+  EXPECT_EQ(0, LogSink::Instance().BackendCount());
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -251,6 +251,11 @@ TEST(ConnectionOptionsTest, DefaultLoggingWithValue) {
   EXPECT_EQ(0, LogSink::Instance().BackendCount());
 }
 
+TEST(ConnectionOptionsTest, DefaultBackgroundThreads) {
+  auto actual = internal::DefaultBackgroundThreads();
+  EXPECT_TRUE(actual);
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include <gmock/gmock.h>
+#include <map>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -20,6 +20,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "async_operation.h",
     "background_threads.h",
     "completion_queue.h",
+    "connection_options.h",
     "grpc_error_delegate.h",
     "grpc_utils/async_operation.h",
     "grpc_utils/completion_queue.h",
@@ -32,6 +33,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
 
 google_cloud_cpp_grpc_utils_srcs = [
     "completion_queue.cc",
+    "connection_options.cc",
     "grpc_error_delegate.cc",
     "internal/background_threads_impl.cc",
     "internal/completion_queue_impl.cc",

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -18,6 +18,7 @@
 
 google_cloud_cpp_grpc_utils_unit_tests = [
     "completion_queue_test.cc",
+    "connection_options_test.cc",
     "grpc_error_delegate_test.cc",
     "internal/background_threads_impl_test.cc",
 ]

--- a/google/cloud/testing_util/environment_variable_restore.h
+++ b/google/cloud/testing_util/environment_variable_restore.h
@@ -38,6 +38,8 @@ class EnvironmentVariableRestore {
     SetUp();
   }
 
+  ~EnvironmentVariableRestore() { TearDown(); }
+
   void SetUp();
   void TearDown();
 


### PR DESCRIPTION
The plan is to copy the class here, and later remove it from spanner, we
need it for Cloud Pub/Sub too. This is not strictly a copy, the defaults
are different for each service, for example: the endpoint. The class is
a template, parametized by traits to set the defaults. Each client
library will instantiate this class with the right set of defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/165)
<!-- Reviewable:end -->
