### PR TITLE
fix: grpc_utils backwards compatibility for Bazel

### DIFF
--- a/ci/test-install/BUILD
+++ b/ci/test-install/BUILD
@@ -23,6 +23,6 @@ cc_test(
     ],
     deps = [
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_grpc_utils",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
     ],
 )

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -66,7 +66,11 @@ load(":google_cloud_cpp_grpc_utils.bzl", "google_cloud_cpp_grpc_utils_hdrs", "go
 cc_library(
     name = "google_cloud_cpp_grpc_utils",
     srcs = google_cloud_cpp_grpc_utils_srcs,
-    hdrs = google_cloud_cpp_grpc_utils_hdrs,
+    hdrs = [
+        header
+        for header in google_cloud_cpp_grpc_utils_hdrs
+        if not "grpc_utils/" in header
+    ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "@com_github_grpc_grpc//:grpc++",

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -66,6 +66,7 @@ load(":google_cloud_cpp_grpc_utils.bzl", "google_cloud_cpp_grpc_utils_hdrs", "go
 cc_library(
     name = "google_cloud_cpp_grpc_utils",
     srcs = google_cloud_cpp_grpc_utils_srcs,
+    # TODO(#171) - remove the filtering comprehension.
     hdrs = [
         header
         for header in google_cloud_cpp_grpc_utils_hdrs

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/grpc_utils/completion_queue.h"
+#include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>

--- a/google/cloud/grpc_utils/BUILD
+++ b/google/cloud/grpc_utils/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+cc_library(
+    name = "google_cloud_cpp_grpc_utils",
+    srcs = [],
+    hdrs = [
+        "async_operation.h",
+        "completion_queue.h",
+        "grpc_error_delegate.h",
+        "version.h",
+    ],
+    deps = [
+        "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googleapis//:grpc_utils_protos",
+    ],
+)

--- a/google/cloud/grpc_utils/BUILD
+++ b/google/cloud/grpc_utils/BUILD
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+# TODO(#171) - remove the backwards compatibility target.
 cc_library(
     name = "google_cloud_cpp_grpc_utils",
     srcs = [],

--- a/google/cloud/samples/BUILD
+++ b/google/cloud/samples/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+cc_test(
+    name = "common_install_test",
+    srcs = ["common_install_test.cc"],
+    deps = [
+        "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googleapis//:grpc_utils_protos",
+        "@com_google_googletest//:gtest",
+    ],
+)


### PR DESCRIPTION
Keep the //google/cloud/grpc_utils:google_cloud_cpp_grpc_utils target
around for backwards compatibility. The backwards compatibility headers
are only available if one uses this target. The new target (one
directory up) only gives you access to the new headers. No changes for
CMake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/170)
<!-- Reviewable:end -->
