### PR TITLE
chore: update docker fragments to use new v0.19 version of common

### DIFF
--- a/ci/templates/kokoro/docker-fragments.sh
+++ b/ci/templates/kokoro/docker-fragments.sh
@@ -17,7 +17,7 @@ read_into_variable WARNING_GENERATED_FILE_FRAGMENT <<'_EOF_'
 #
 # WARNING: This is an automatically generated file. Consider changing the
 #     sources instead. You can find the source templates and scripts at:
-#         https://github.com/googleapis/google-cloud-cpp-common/ci/templates
+#     https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
 #
 _EOF_
 
@@ -112,9 +112,9 @@ _EOF_
 
 read_into_variable INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.18.0.tar.gz && \
-    tar -xf v0.18.0.tar.gz && \
-    cd google-cloud-cpp-common-0.18.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
+    tar -xf v0.19.0.tar.gz && \
+    cd google-cloud-cpp-common-0.19.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -82,10 +82,17 @@ uploaded documentation will generally be live in an hour at the
 
 ## Bump the version numbers in `master`
 
-Working in your fork of `gooogle-cloud-cpp-common`: bump the version numbers
-to the *next* version (i.e., one version past the release you just did above),
-and send the PR for review against `master`. For an example, look at
-[#90](https://github.com/googleapis/google-cloud-cpp-common/pull/90).
+Working in your fork of `gooogle-cloud-cpp-common`:
+
+* Bump the version numbers to the *next* version (i.e., one version past the
+  release you just did above).
+
+* Update the version of the "google-cloud-cpp-common" package in the
+  `ci/templates/kokoro/docker-fragments.sh` file to reflect the *just released
+  version*. This will make it easier for our dependent projects to update their
+  docker deps to use this new version.
+
+Send these changes in PR for review against `master`.
 
 ## Review the branch protections
 


### PR DESCRIPTION
In the future, this should probably be during while cutting the release, so I updated the release instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/176)
<!-- Reviewable:end -->
