### PR TITLE
fix: use BUILD_ALWAYS in super build

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -41,6 +41,7 @@ additional_commands = {
             "PREFIX": 1,
             "URL": 1,
             "URL_HASH": 1,
+            "BUILD_ALWAYS": 1,
         }
     }
 }

--- a/super/CMakeLists.txt
+++ b/super/CMakeLists.txt
@@ -39,6 +39,7 @@ ExternalProject_Add(
     google-cloud-cpp-project
     DEPENDS ${GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST}
     EXCLUDE_FROM_ALL OFF
+    BUILD_ALWAYS 1
     PREFIX "${CMAKE_BINARY_DIR}/build/google-cloud-cpp"
     INSTALL_DIR
         "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"


### PR DESCRIPTION
Sometimes we want to use a super build for development (or users might
use a super build for exploration), without BUILD_ALWAYS the code is not
compiled after a change.

Also fixed formatting configuration for cmake-format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/192)
<!-- Reviewable:end -->
