### PR TITLE
fix: workaround a libstdc++ on random_device

### DIFF
--- a/google/cloud/internal/random.cc
+++ b/google/cloud/internal/random.cc
@@ -23,7 +23,7 @@ namespace internal {
 std::vector<unsigned int> FetchEntropy(std::size_t desired_bits) {
   // We use the default C++ random device to generate entropy.  The quality of
   // this source of entropy is implementation-defined. The version in
-  // Linux with libstdc++ (the most common library on Linux) it is based on
+  // Linux with libstdc++ (the most common library on Linux) is based on
   // either `/dev/urandom`, or (if available) the RDRAND, or the RDSEED CPU
   // instruction.
   //     http://en.cppreference.com/w/cpp/numeric/random/random_device/random_device
@@ -52,8 +52,7 @@ std::vector<unsigned int> FetchEntropy(std::size_t desired_bits) {
 #endif  // defined(__GLIBCXX__) && __GLIBCXX__ >= 20200128
 
   auto constexpr kWordSize = std::numeric_limits<unsigned int>::digits;
-  auto const n = desired_bits / kWordSize +
-                 static_cast<int>(desired_bits % kWordSize != 0);
+  auto const n = (desired_bits + kWordSize - 1) / kWordSize;
   std::vector<unsigned int> entropy(n);
   std::generate(entropy.begin(), entropy.end(), [&rd]() { return rd(); });
   return entropy;

--- a/google/cloud/internal/random.cc
+++ b/google/cloud/internal/random.cc
@@ -13,11 +13,52 @@
 // limitations under the License.
 
 #include "google/cloud/internal/random.h"
+#include <algorithm>
+#include <limits>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
+std::vector<unsigned int> FetchEntropy(std::size_t desired_bits) {
+  // We use the default C++ random device to generate entropy.  The quality of
+  // this source of entropy is implementation-defined. The version in
+  // Linux with libstdc++ (the most common library on Linux) it is based on
+  // either `/dev/urandom`, or (if available) the RDRAND, or the RDSEED CPU
+  // instruction.
+  //     http://en.cppreference.com/w/cpp/numeric/random/random_device/random_device
+  //
+  // On Linux with libc++ it is also based on `/dev/urandom`, but it is not
+  // known if it uses the RDRAND CPU instruction (though `/dev/urandom` does).
+  //
+  // On Windows the documentation says that the numbers are not deterministic,
+  // and cryptographically secure, but no further details are available:
+  //     https://docs.microsoft.com/en-us/cpp/standard-library/random-device-class
+  //
+  // One would want to simply pass this object to the constructor for the
+  // generator, but the C++11 approach is annoying, see this critique for
+  // the details:
+  //     http://www.pcg-random.org/posts/simple-portable-cpp-seed-entropy.html
+
+#if defined(__GLIBCXX__) && __GLIBCXX__ >= 20200128
+  // Workaround for a libstd++ bug:
+  //     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
+  // we cannot simply use `rdrand` everywhere because this is library and
+  // version specific, i.e., other standard C++ libraries do not support
+  // `rdrand`, and even older versions of libstdc++ do not support `rdrand`.
+  std::random_device rd("rdrand");
+#else
+  std::random_device rd;
+#endif  // defined(__GLIBCXX__) && __GLIBCXX__ >= 20200128
+
+  auto constexpr kWordSize = std::numeric_limits<unsigned int>::digits;
+  auto const n = desired_bits / kWordSize +
+                 static_cast<int>(desired_bits % kWordSize != 0);
+  std::vector<unsigned int> entropy(n);
+  std::generate(entropy.begin(), entropy.end(), [&rd]() { return rd(); });
+  return entropy;
+}
+
 std::string Sample(DefaultPRNG& gen, int n, std::string const& population) {
   std::uniform_int_distribution<std::size_t> rd(0, population.size() - 1);
 

--- a/google/cloud/internal/random_test.cc
+++ b/google/cloud/internal/random_test.cc
@@ -53,14 +53,10 @@ TEST(Random, Threads) {
 
   int count = 0;
   for (auto& f : workers) {
-    try {
-      int result = f.get();
-      EXPECT_EQ(result, kIterations);
-    } catch (std::runtime_error const& ex) {
-      EXPECT_TRUE(false) << "unexpected exception throw by worker " << count
-                         << ": " << ex.what() << "\n";
-    }
-    ++count;
+    SCOPED_TRACE("testing with worker " + std::to_string(count++));
+    int result = 0;
+    EXPECT_NO_THROW(result = f.get());
+    EXPECT_EQ(result, kIterations);
   }
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/internal/random_test.cc
+++ b/google/cloud/internal/random_test.cc
@@ -32,10 +32,16 @@ TEST(Random, Basic) {
   EXPECT_NE(s0, s1);
 }
 
-// The bug the C++ standard library throws an exception when the bug is
-// triggered, without exceptions the test would just crash.
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-// @test verify that multiple threads can call
+/**
+ * @test verify that multiple threads can call MakeDefaultPRNG() simultaneously.
+ *
+ * This test verifies our code works around a bug in libstdc++:
+ *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087
+ * When this bug is triggered, the standard library throws an exception and
+ * the test would just crash (or not compile, as we use EXPECT_NO_THROW). It is
+ * simpler to compile the test only when exceptions are enabled.
+ */
 TEST(Random, Threads) {
   auto constexpr kNumWorkers = 64;
   auto constexpr kIterations = 100;


### PR DESCRIPTION
On fairly recent versions of libstdc++ the `std::random_device` class
fails when used by multiple threads:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94087

We workaround this problem by detecting the version of the standard C++
library, and if it is `libstdc++` and it is a version after 20200128
then we use `rdrand` as the token value to initialize
`std::random_device`, which does not have the problem with multiple
threads.

Part of the work for googleapis/google-cloud-cpp#3437

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/208)
<!-- Reviewable:end -->
