### PR TITLE
fix: correct logic in release script

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -86,7 +86,7 @@ trap exit_handler EXIT
 # we make sure it's installed early on so we don't fail after completing part
 # of the release. We also use 'hub' to do the clone so that the user is asked
 # to authenticate at the beginning of the process rather than at the end.
-if command -v hub > /dev/null; then
+if ! command -v hub > /dev/null; then
   echo "Can't find 'hub' command"
   echo "Maybe run: sudo apt install hub"
   echo "Or build it from https://github.com/github/hub"


### PR DESCRIPTION
I broke this in a previous PR cleaning up shellcheck warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/216)
<!-- Reviewable:end -->
