### PR TITLE
doc: copy the `Include Guards` section from the -cpp repo

### DIFF
--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -13,7 +13,7 @@ All header files should have include guards formatted like
 `PROJECT_DIR_FILE_H`. This differs from the advice in the GSG in that ours do
 not end with a trailing underscore.
 
-[link to GSG's section on include guards](https://google.github.io/styleguide/cppguide.html#The__define_Guard) 
+[link to GSG's section on include guards](https://google.github.io/styleguide/cppguide.html#The__define_Guard)
 
 ## Reference Arguments
 

--- a/doc/cpp-style-guide.md
+++ b/doc/cpp-style-guide.md
@@ -7,6 +7,14 @@ differ from the GSG.
 
 [google-style-guide-link]: https://google.github.io/styleguide/cppguide.html
 
+## Include Guards
+
+All header files should have include guards formatted like
+`PROJECT_DIR_FILE_H`. This differs from the advice in the GSG in that ours do
+not end with a trailing underscore.
+
+[link to GSG's section on include guards](https://google.github.io/styleguide/cppguide.html#The__define_Guard) 
+
 ## Reference Arguments
 
 Function return values are preferred over argument out-params. However, when an


### PR DESCRIPTION
All of our repos follow this convention so it belongs in common.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/217)
<!-- Reviewable:end -->
