### PR TITLE
fix: let clang-tidy allow bool conversions in conditions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -73,3 +73,5 @@ CheckOptions:
   - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
   - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
   - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
+  - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1   }


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-cpp-spanner/pull/1377 for rationale.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/235)
<!-- Reviewable:end -->
