### PR TITLE
feat: add timestamps in default log backend

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,10 +39,11 @@ Checks: >
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
   -modernize-return-braced-init-list,
-  -performance-move-const-arg,
-  -readability-named-parameter,
   -modernize-use-trailing-return-type,
+  -performance-move-const-arg,
   -readability-braces-around-statements,
+  -readability-magic-numbers,
+  -readability-named-parameter,
   -readability-redundant-declaration
 
 # Turn all the warnings from the checks above into errors.

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,11 +39,10 @@ Checks: >
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
   -modernize-return-braced-init-list,
-  -modernize-use-trailing-return-type,
   -performance-move-const-arg,
-  -readability-braces-around-statements,
-  -readability-magic-numbers,
   -readability-named-parameter,
+  -modernize-use-trailing-return-type,
+  -readability-braces-around-statements,
   -readability-redundant-declaration
 
 # Turn all the warnings from the checks above into errors.

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -15,10 +15,14 @@
 #include "google/cloud/log.h"
 #include "google/cloud/internal/getenv.h"
 #include <array>
+#include <cstdint>
+#include <ctime>
+#include <iomanip>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
+
 static_assert(sizeof(Severity) <= sizeof(int),
               "Expected Severity to fit in an integer");
 
@@ -26,28 +30,60 @@ static_assert(static_cast<int>(Severity::GCP_LS_LOWEST) <
                   static_cast<int>(Severity::GCP_LS_HIGHEST),
               "Expect LOWEST severity to be smaller than HIGHEST severity");
 
+namespace {
+struct Timestamp {
+  explicit Timestamp(std::chrono::system_clock::time_point const& tp) {
+    auto const tt = std::chrono::system_clock::to_time_t(tp);
+#if defined(_WIN32)
+    gmtime_s(&tm, &tt);
+#else
+    gmtime_r(&tt, &tm);
+#endif
+    auto const ss = tp - std::chrono::system_clock::from_time_t(tt);
+    nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(ss).count();
+  }
+  std::tm tm;
+  std::int32_t nanos;
+};
+
+std::ostream& operator<<(std::ostream& os, Timestamp const& ts) {
+  auto const prev = os.fill(' ');
+  os << std::setw(4) << ts.tm.tm_year + 1900;
+  os.fill('0');
+  os << '-' << std::setw(2) << ts.tm.tm_mon + 1;
+  os << '-' << std::setw(2) << ts.tm.tm_mday;
+  os << 'T' << std::setw(2) << ts.tm.tm_hour;
+  os << ':' << std::setw(2) << ts.tm.tm_min;
+  os << ':' << std::setw(2) << ts.tm.tm_sec;
+  os << '.' << std::setw(9) << ts.nanos << 'Z';
+  os.fill(prev);
+  return os;
+}
+
+auto constexpr kSeverityCount = static_cast<int>(Severity::GCP_LS_HIGHEST) + 1;
+
+// Double braces needed to workaround a clang-3.8 bug.
+std::array<char const*, kSeverityCount> constexpr kSeverityNames{{
+    "TRACE",
+    "DEBUG",
+    "INFO",
+    "NOTICE",
+    "WARNING",
+    "ERROR",
+    "CRITICAL",
+    "ALERT",
+    "FATAL",
+}};
+}  // namespace
+
 std::ostream& operator<<(std::ostream& os, Severity x) {
-  auto constexpr kSeverityCount =
-      static_cast<int>(Severity::GCP_LS_HIGHEST) + 1;
-  // Double braces needed to workaround a clang-3.8 bug.
-  std::array<char const*, kSeverityCount> names{{
-      "TRACE",
-      "DEBUG",
-      "INFO",
-      "NOTICE",
-      "WARNING",
-      "ERROR",
-      "CRITICAL",
-      "ALERT",
-      "FATAL",
-  }};
   auto index = static_cast<int>(x);
-  return os << names[index];
+  return os << kSeverityNames[index];
 }
 
 std::ostream& operator<<(std::ostream& os, LogRecord const& rhs) {
-  return os << '[' << rhs.severity << "] " << rhs.message << " ("
-            << rhs.filename << ':' << rhs.lineno << ')';
+  return os << Timestamp{rhs.timestamp} << " [" << rhs.severity << "] "
+            << rhs.message << " (" << rhs.filename << ':' << rhs.lineno << ')';
 }
 
 LogSink::LogSink()

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -48,13 +48,15 @@ struct Timestamp {
 
 std::ostream& operator<<(std::ostream& os, Timestamp const& ts) {
   auto const prev = os.fill(' ');
-  os << std::setw(4) << ts.tm.tm_year + 1900;
+  auto constexpr kTmYearOffset = 1900;
+  os << std::setw(4) << ts.tm.tm_year + kTmYearOffset;
   os.fill('0');
   os << '-' << std::setw(2) << ts.tm.tm_mon + 1;
   os << '-' << std::setw(2) << ts.tm.tm_mday;
   os << 'T' << std::setw(2) << ts.tm.tm_hour;
   os << ':' << std::setw(2) << ts.tm.tm_min;
   os << ':' << std::setw(2) << ts.tm.tm_sec;
+  // NOLINTNEXTLINE(readability-magic-numbers)
   os << '.' << std::setw(9) << ts.nanos << 'Z';
   os.fill(prev);
   return os;

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -14,6 +14,7 @@
 
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOG_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOG_H
+
 /**
  * @file log.h
  *
@@ -222,7 +223,7 @@ struct LogRecord {
 std::ostream& operator<<(std::ostream& os, LogRecord const& rhs);
 
 /**
- * A sink to receive log records.
+ * The logging backend interface.
  */
 class LogBackend {
  public:
@@ -233,7 +234,7 @@ class LogBackend {
 };
 
 /**
- *
+ * A sink to receive log records.
  */
 class LogSink {
  public:

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {
@@ -30,6 +31,21 @@ TEST(LogSeverityTest, Streaming) {
   std::ostringstream os;
   os << Severity::GCP_LS_TRACE;
   EXPECT_EQ("TRACE", os.str());
+}
+
+TEST(LogRecordTest, Streaming) {
+  std::ostringstream os;
+  LogRecord lr;
+  lr.severity = Severity::GCP_LS_INFO;
+  lr.function = "Func";
+  lr.filename = "filename.cc";
+  lr.lineno = 123;
+  lr.timestamp = std::chrono::system_clock::from_time_t(1585112316) +
+                 std::chrono::microseconds(123456);
+  lr.message = "message";
+  os << lr;
+  EXPECT_EQ("2020-03-25T04:58:36.123456000Z [INFO] message (filename.cc:123)",
+            os.str());
 }
 
 TEST(LogSinkTest, CompileTimeEnabled) {


### PR DESCRIPTION
Timestamps are always rendered in "Zulu" time, and with nanosecond
resolution (no matter what the actual resolution of a platform's
`system_clock::time_point`).

Also disable the "readability-magic-numbers" clang tidy.  It is too
conservative for our liking.

Fixes #261.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/266)
<!-- Reviewable:end -->
