### PR TITLE
fix: copy .clang-format from -spanner

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,8 +9,11 @@ PointerAlignment: Left
 
 IncludeBlocks: Merge
 IncludeCategories:
-- Regex: '^\"google/cloud/'
+# Matches common headers first, but sorts them after project includes
+- Regex: '^\"google/cloud/(internal/|grpc_utils/|testing_util/|[^/]+\.h)'
   Priority: 1500
+- Regex: '^\"google/cloud/'  # project includes should sort first
+  Priority: 500
 - Regex: '^\"'
   Priority: 1000
 - Regex: '^<grpc/'
@@ -21,3 +24,13 @@ IncludeCategories:
   Priority: 4000
 - Regex: '^<[^/]*>'
   Priority: 5000
+
+# Format raw string literals with a `pb` or `proto` tag as proto.
+RawStringFormats:
+- Language: TextProto
+  Delimiters:
+  - 'pb'
+  - 'proto'
+  BasedOnStyle: Google
+
+CommentPragmas: '(@copydoc)'


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/3596

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/267)
<!-- Reviewable:end -->
