### PR TITLE
ci: preemptively create ccache config

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -85,6 +85,11 @@ if [[ "${USE_NINJA:-}" == "yes" ]]; then
   cmake_extra_flags+=( "-GNinja" )
 fi
 
+# From time to time the builds fail because this file does not exist, create it
+# just to make the builds more reliable.
+mkdir -p "${HOME}/.ccache"
+echo "max_size = 4.0G" >"${HOME}/.ccache/ccache.conf"
+
 # We use parameter expansion for ${cmake_extra_flags} because set -u doesn't
 # like empty arrays on older versions of Bash (which some of our builds use).
 # The expression ${parameter+word} will expand word only if parameter is not


### PR DESCRIPTION
This fixes #269 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/270)
<!-- Reviewable:end -->
