### PR TITLE
fix(cmake): typo when looking for protobuf-config

### DIFF
--- a/cmake/FindProtobufWithTargets.cmake
+++ b/cmake/FindProtobufWithTargets.cmake
@@ -83,7 +83,7 @@ find_package(Threads REQUIRED)
 # where protobuf was compiled and installed with `CMake`. Note that on Linux
 # this *must* be all lowercase ``protobuf``, while on Windows it does not
 # matter.
-find_package(protobuf CONFIG QUIET)
+find_package(Protobuf CONFIG QUIET)
 
 if (protobuf_DEBUG)
     message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "


### PR DESCRIPTION
@coryan Same trouble as with google-cloud-cpp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/275)
<!-- Reviewable:end -->
