### PR TITLE
fix: minimize targets in overlay build_file

### DIFF
--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -17,14 +17,12 @@ licenses(["notice"])  # Apache 2.0
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
+# This rule lets us include all the headers from googleapis targets using angle
+# brackets so they look like system includes.
 cc_library(
-    name = "grpc_utils_protos",
+    name = "googleapis_system_includes",
     includes = [
         ".",
-    ],
-    deps = [
-        "@com_github_grpc_grpc//:grpc++",
-        "//google/rpc:status_cc_proto"
     ],
 )
 

--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 package(default_visibility = ["//visibility:public"])
+
 licenses(["notice"])  # Apache 2.0
 
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
-
-# This rule lets us include all the headers from googleapis targets using angle
-# brackets so they look like system includes.
+# This rule lets us include headers from googleapis targets using angle
+# brackets like system includes.
 cc_library(
     name = "googleapis_system_includes",
     includes = [
@@ -26,52 +25,3 @@ cc_library(
     ],
 )
 
-cc_proto_library(
-    name = "bigtableadmin_cc_proto",
-    deps = ["//google/bigtable/admin/v2:admin_proto"],
-)
-
-cc_proto_library(
-    name = "bigtable_cc_proto",
-    deps = ["//google/bigtable/v2:bigtable_proto"],
-)
-
-cc_grpc_library(
-    name = "bigtableadmin_cc_grpc",
-    srcs = [
-        "//google/bigtable/admin/v2:admin_proto",
-    ],
-    grpc_only = True,
-    use_external = True,
-    well_known_protos = True,
-    deps = [
-        ":bigtableadmin_cc_proto",
-        "//google/longrunning:longrunning_cc_grpc"
-    ],
-)
-
-cc_grpc_library(
-    name = "bigtable_cc_grpc",
-    srcs = ["//google/bigtable/v2:bigtable_proto"],
-    grpc_only = True,
-    use_external = True,
-    well_known_protos = True,
-    deps = [
-        ":bigtable_cc_proto",
-    ],
-)
-
-cc_library(
-    name = "bigtable_protos",
-    includes = [
-        ".",
-    ],
-    deps = [
-        "@com_github_grpc_grpc//:grpc++",
-        ":bigtable_cc_grpc",
-        ":bigtable_cc_proto",
-        ":bigtableadmin_cc_grpc",
-        ":bigtableadmin_cc_proto",
-        "//google/rpc:error_details_cc_proto"
-    ],
-)

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -56,7 +56,6 @@ load(
     deps = [
         ":google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in google_cloud_cpp_common_unit_tests]
@@ -73,9 +72,11 @@ cc_library(
         if not "grpc_utils/" in header
     ],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
+        ":google_cloud_cpp_common",
         "@com_github_grpc_grpc//:grpc++",
-        "@com_google_googleapis//:grpc_utils_protos",
+        "@com_google_googleapis//:googleapis_system_includes",
+        "@com_google_googleapis//google/rpc:status_cc_proto",
+
     ],
 )
 
@@ -85,13 +86,11 @@ load(":google_cloud_cpp_grpc_utils_unit_tests.bzl", "google_cloud_cpp_grpc_utils
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     deps = [
+        ":google_cloud_cpp_common",
         ":google_cloud_cpp_grpc_utils",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
-        "@com_github_grpc_grpc//:grpc++",
         "@com_google_googleapis//:bigtable_protos",
-        "@com_google_googleapis//:grpc_utils_protos",
         "@com_google_googletest//:gtest",
     ],
 ) for test in google_cloud_cpp_grpc_utils_unit_tests]

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -76,7 +76,6 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_googleapis//:googleapis_system_includes",
         "@com_google_googleapis//google/rpc:status_cc_proto",
-
     ],
 )
 
@@ -90,7 +89,8 @@ load(":google_cloud_cpp_grpc_utils_unit_tests.bzl", "google_cloud_cpp_grpc_utils
         ":google_cloud_cpp_grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
-        "@com_google_googleapis//:bigtable_protos",
+        "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
+        "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
         "@com_google_googletest//:gtest",
     ],
 ) for test in google_cloud_cpp_grpc_utils_unit_tests]

--- a/google/cloud/grpc_utils/BUILD
+++ b/google/cloud/grpc_utils/BUILD
@@ -29,7 +29,5 @@ cc_library(
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
-        "@com_github_grpc_grpc//:grpc++",
-        "@com_google_googleapis//:grpc_utils_protos",
     ],
 )

--- a/google/cloud/samples/BUILD
+++ b/google/cloud/samples/BUILD
@@ -23,8 +23,6 @@ cc_test(
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
         "//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
-        "@com_github_grpc_grpc//:grpc++",
-        "@com_google_googleapis//:grpc_utils_protos",
         "@com_google_googletest//:gtest",
     ],
 )


### PR DESCRIPTION
We want to minimize the custom targets that we add to overlay `build_file`s, because these are deps that our *customers* will also have to define in their overlay build files as well. So any targets we add should be few and important.

This PR removes all of our overlay targets except for a single one called "googleapis_system_includes", which lets us include googleapis protos using angle brackets. Yes, customers will still need to define this target, but it's a single target and a simple one. If one day we can get rid of this one too, even better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/279)
<!-- Reviewable:end -->
