### PR TITLE
cleanup: make unit test target names unique

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -240,9 +240,11 @@ if (BUILD_TESTING)
                          "google_cloud_cpp_common_unit_tests")
 
     foreach (fname ${google_cloud_cpp_common_unit_tests})
-        string(REPLACE "/" "_" target ${fname})
-        string(REPLACE ".cc" "" target ${target})
+        string(REPLACE "/" "_" basename ${fname})
+        string(REPLACE ".cc" "" basename ${basename})
+        set(target "google_cloud_cpp_common_${basename}")
         add_executable(${target} ${fname})
+        set_target_properties(${target} PROPERTIES OUTPUT_NAME ${basename})
         target_link_libraries(
             ${target}
             PRIVATE google_cloud_cpp_testing google_cloud_cpp_common
@@ -371,9 +373,11 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
                              "google_cloud_cpp_grpc_utils_unit_tests" YEAR 2019)
 
         foreach (fname ${google_cloud_cpp_grpc_utils_unit_tests})
-            string(REPLACE "/" "_" target ${fname})
-            string(REPLACE ".cc" "" target ${target})
+            string(REPLACE "/" "_" basename ${fname})
+            string(REPLACE ".cc" "" basename ${basename})
+            set(target "google_cloud_cpp_grpc_utils_${basename}")
             add_executable(${target} ${fname})
+            set_target_properties(${target} PROPERTIES OUTPUT_NAME ${basename})
             target_link_libraries(
                 ${target}
                 PRIVATE google_cloud_cpp_grpc_utils

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -48,9 +48,11 @@ if (BUILD_TESTING OR GOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL)
                          "google_cloud_cpp_testing_unit_tests")
 
     foreach (fname ${google_cloud_cpp_testing_unit_tests})
-        string(REPLACE "/" "_" target ${fname})
-        string(REPLACE ".cc" "" target ${target})
+        string(REPLACE "/" "_" basename ${fname})
+        string(REPLACE ".cc" "" basename ${basename})
+        set(target "google_cloud_cpp_testing_${basename}")
         add_executable(${target} ${fname})
+        set_target_properties(${target} PROPERTIES OUTPUT_NAME ${basename})
         target_link_libraries(
             ${target}
             PRIVATE google_cloud_cpp_testing google_cloud_cpp_common
@@ -80,9 +82,11 @@ if (BUILD_TESTING OR GOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL)
                          "google_cloud_cpp_testing_grpc_unit_tests" YEAR 2020)
 
     foreach (fname ${google_cloud_cpp_testing_grpc_unit_tests})
-        string(REPLACE "/" "_" target ${fname})
-        string(REPLACE ".cc" "" target ${target})
+        string(REPLACE "/" "_" basename ${fname})
+        string(REPLACE ".cc" "" basename ${basename})
+        set(target "google_cloud_cpp_testing_grpc_${basename}")
         add_executable(${target} ${fname})
+        set_target_properties(${target} PROPERTIES OUTPUT_NAME ${basename})
         target_link_libraries(
             ${target}
             PRIVATE google_cloud_cpp_testing_grpc


### PR DESCRIPTION
CMake requires target names to be unique, even in different directories.
Fortunately the target name can be different from the binary name,
though it requires a little more work to make it so. Unit tests are more
likely to repeat names, so use a prefix to minimize the possibility of
collisions. The other targets can be handled on a ad-hoc basis when and
if we have a target name collision.

Part of the work for googleapis/google-cloud-cpp#3548

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/280)
<!-- Reviewable:end -->
