### PR TITLE
ci: update templates for Ubuntu:Focal

### DIFF
--- a/ci/templates/generate-kokoro-install.sh
+++ b/ci/templates/generate-kokoro-install.sh
@@ -46,6 +46,7 @@ BUILD_NAMES=(
   opensuse-tumbleweed
   ubuntu-xenial
   ubuntu-bionic
+  ubuntu-focal
 )
 readonly BUILD_NAMES
 

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-focal.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-focal.in
@@ -1,0 +1,52 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+@WARNING_GENERATED_FILE_FRAGMENT@
+
+ARG DISTRO_VERSION=focal
+FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
+
+## [START INSTALL.md]
+
+# Install the minimal development tools, libcurl, OpenSSL and libc-ares:
+
+# ```bash
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y apt-transport-https apt-utils \
+        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
+        pkg-config tar wget zlib1g-dev
+# ```
+
+# #### Protobuf
+
+# We need to install a version of Protobuf that is recent enough to support the
+# Google Cloud Platform proto files:
+
+# ```bash
+@INSTALL_PROTOBUF_FROM_SOURCE@
+# ```
+
+# #### gRPC
+
+# We also need a version of gRPC that is recent enough to support the Google
+# Cloud Platform proto files. We install it using:
+
+# ```bash
+@INSTALL_GRPC_FROM_SOURCE@
+# ```
+
+@BUILD_AND_TEST_PROJECT_FRAGMENT@

--- a/ci/templates/kokoro/install/build.sh.in
+++ b/ci/templates/kokoro/install/build.sh.in
@@ -53,7 +53,10 @@ if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
 fi
 
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
-  readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
+  readonly PROJECT_ROOT="$(
+    cd "$(dirname "$0")/../../.."
+    pwd
+  )"
 fi
 source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 
@@ -99,18 +102,18 @@ if "${has_cache}"; then
   devtools_flags+=("--cache-from=${INSTALL_IMAGE}:latest")
 fi
 
-if [[ "${RUNNING_CI:-}" == "yes" ]] && \
-   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+if [[ "${RUNNING_CI:-}" == "yes" ]] &&
+  [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
   devtools_flags+=("--no-cache")
 fi
 
 echo "Running docker build with " "${devtools_flags[@]}"
 if docker build "${devtools_flags[@]}" ci; then
-   update_cache="true"
+  update_cache="true"
 fi
 
 if "${update_cache}" && [[ "${RUNNING_CI:-}" == "yes" ]] &&
-   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+  [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
   echo "================================================================"
   echo "Uploading updated base image for ${DISTRO} $(date)."
   # Do not stop the build on a failure to update the cache.


### PR DESCRIPTION
Ubuntun:20.04 (Focal Fossa) recently became available, this PR creates a
template for it and fixes the `build.sh.in` template to be compatible
with shmft.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/281)
<!-- Reviewable:end -->
