### PR TITLE
fix: avoid warnings in newer CMake versions

### DIFF
--- a/cmake/FindgRPC.cmake
+++ b/cmake/FindgRPC.cmake
@@ -65,10 +65,9 @@ endif ()
 # gRPC always requires Thread support.
 find_package(Threads REQUIRED)
 
-# Load the module to find protobuf with proper targets. Do not use
-# `find_package()` because we (have to) install this module in non-standard
-# locations.
-include(${CMAKE_CURRENT_LIST_DIR}/FindProtobufWithTargets.cmake)
+# Load the module to find protobuf with proper targets.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+find_package(ProtobufWithTargets)
 
 # The gRPC::grpc_cpp_plugin target is sometimes defined, but without a
 # IMPORTED_LOCATION


### PR DESCRIPTION
Newer versions of CMake warn about using
`find_package_handle_standard_args()` through an include (correctly so),
so use `find_package()` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/283)
<!-- Reviewable:end -->
