### PR TITLE
chore: pin copyright year for generated .bzl files

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -201,7 +201,7 @@ set_target_properties(
                SOVERSION ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})
 
 include(CreateBazelConfig)
-create_bazel_config(google_cloud_cpp_common)
+create_bazel_config(google_cloud_cpp_common YEAR 2018)
 google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 
 add_subdirectory(testing_util)
@@ -237,7 +237,7 @@ if (BUILD_TESTING)
 
     # Export the list of unit tests so the Bazel BUILD file can pick it up.
     export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"
-                         "google_cloud_cpp_common_unit_tests")
+                         "google_cloud_cpp_common_unit_tests" YEAR 2018)
 
     foreach (fname ${google_cloud_cpp_common_unit_tests})
         string(REPLACE "/" "_" basename ${fname})

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -45,7 +45,7 @@ if (BUILD_TESTING OR GOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL)
 
     # Export the list of unit tests so the Bazel BUILD file can pick it up.
     export_list_to_bazel("google_cloud_cpp_testing_unit_tests.bzl"
-                         "google_cloud_cpp_testing_unit_tests")
+                         "google_cloud_cpp_testing_unit_tests" YEAR 2018)
 
     foreach (fname ${google_cloud_cpp_testing_unit_tests})
         string(REPLACE "/" "_" basename ${fname})


### PR DESCRIPTION
When we move the code to `g-c-pp` we do not want the copyright year to
change just because the implementation of the export functions may have
a different default.

Fixes #3907

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/284)
<!-- Reviewable:end -->
