### PR TITLE
ci: support ccache in install builds

### DIFF
--- a/ci/templates/generate-kokoro-install.sh
+++ b/ci/templates/generate-kokoro-install.sh
@@ -89,6 +89,7 @@ git -C "${DESTINATION_ROOT}" checkout -- "ci/kokoro/install/common.cfg"
 
 replace_fragments \
   "WARNING_GENERATED_FILE_FRAGMENT" \
+  "GOOGLE_CLOUD_CPP_REPOSITORY" \
   <"${PROJECT_ROOT}/ci/templates/kokoro/install/build.sh.in" \
   >"${DESTINATION_ROOT}/ci/kokoro/install/build.sh"
 chmod 755 "${DESTINATION_ROOT}/ci/kokoro/install/build.sh"

--- a/ci/templates/kokoro/install/Dockerfile.centos-7.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-7.in
@@ -30,7 +30,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN yum install -y centos-release-scl yum-utils
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && \
-    yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
+    yum install -y automake ccache cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar wget which zlib-devel
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
 # ```

--- a/ci/templates/kokoro/install/Dockerfile.centos-8.in
+++ b/ci/templates/kokoro/install/Dockerfile.centos-8.in
@@ -25,7 +25,9 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+    dnf install -y epel-release && \
+    dnf makecache && \
+    dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 

--- a/ci/templates/kokoro/install/Dockerfile.debian-buster.in
+++ b/ci/templates/kokoro/install/Dockerfile.debian-buster.in
@@ -25,7 +25,7 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ca-certificates cmake git gcc g++ cmake \
+        automake build-essential ca-certificates ccache cmake git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
+++ b/ci/templates/kokoro/install/Dockerfile.debian-stretch.in
@@ -32,9 +32,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake libc-ares-dev \
-        libc-ares2 libcurl4-openssl-dev libssl1.0-dev make m4 pkg-config tar \
-        wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make m4 \
+        pkg-config tar wget zlib1g-dev
 # ```
 
 # #### Protobuf

--- a/ci/templates/kokoro/install/Dockerfile.fedora.in
+++ b/ci/templates/kokoro/install/Dockerfile.fedora.in
@@ -24,7 +24,7 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+    dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel
 # ```
 

--- a/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
+++ b/ci/templates/kokoro/install/Dockerfile.opensuse-leap.in
@@ -27,8 +27,8 @@ ARG NCPU=4
 
 # ```bash
 RUN zypper refresh && \
-    zypper install --allow-downgrade -y automake cmake gcc gcc-c++ git gzip \
-        libcurl-devel libopenssl-devel libtool make tar wget which
+    zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
+        gzip libcurl-devel libopenssl-devel libtool make tar wget which
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. openSUSE

--- a/ci/templates/kokoro/install/Dockerfile.opensuse-tumbleweed.in
+++ b/ci/templates/kokoro/install/Dockerfile.opensuse-tumbleweed.in
@@ -24,7 +24,7 @@ ARG NCPU=4
 
 # ```bash
 RUN zypper refresh && \
-    zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+    zypper install --allow-downgrade -y ccache cmake gcc gcc-c++ git gzip \
         libcurl-devel libopenssl-devel make tar wget zlib-devel
 # ```
 

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-bionic.in
@@ -25,7 +25,7 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-focal.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-focal.in
@@ -26,7 +26,7 @@ ARG NCPU=4
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
+++ b/ci/templates/kokoro/install/Dockerfile.ubuntu-xenial.in
@@ -25,7 +25,7 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libcurl4-openssl-dev libssl-dev libtool m4 make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/templates/kokoro/install/build.sh.in
+++ b/ci/templates/kokoro/install/build.sh.in
@@ -45,30 +45,37 @@ else
   exit 1
 fi
 
-echo "================================================================"
-echo "Load Google Container Registry configuration parameters $(date)."
-
-if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
-  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
-fi
-
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(
     cd "$(dirname "$0")/../../.."
     pwd
   )"
 fi
+source "${PROJECT_ROOT}/ci/colors.sh"
+
+# ATTENTION: The gcr-configuration.sh script MUST be sourced first if present.
+echo "================================================================"
+log_normal "Load Google Container Registry configuration parameters."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+# ATTENTION: The gcr-configuration.sh script MUST be sourced before this file.
 source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 
+GCLOUD=gcloud
+source "${PROJECT_ROOT}/ci/kokoro/gcloud-functions.sh"
+source "${PROJECT_ROOT}/ci/kokoro/cache-functions.sh"
+
 echo "================================================================"
-echo "Change working directory to project root $(date)."
+log_yellow "Change working directory to project root."
 cd "${PROJECT_ROOT}"
 
 echo "================================================================"
-echo "Building with ${NCPU} cores $(date) on ${PWD}."
+log_normal "Building with ${NCPU} cores on ${PWD}."
 
 echo "================================================================"
-echo "Setup Google Container Registry access $(date)."
+log_normal "Setup Google Container Registry access."
 if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
   gcloud auth activate-service-account --key-file \
     "${KOKORO_GFILE_DIR}/gcr-service-account.json"
@@ -76,15 +83,24 @@ fi
 gcloud auth configure-docker
 
 echo "================================================================"
-echo "Download existing image (if available) for ${DISTRO} $(date)."
+log_normal "Download existing image (if available) for ${DISTRO}."
 has_cache="false"
 if docker pull "${INSTALL_IMAGE}:latest"; then
   echo "Existing image successfully downloaded."
   has_cache="true"
 fi
 
+readonly CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
+readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/@GOOGLE_CLOUD_CPP_REPOSITORY@/master/install"
+readonly CACHE_NAME="${DISTRO}.tar.gz"
+
+if cache_download_enabled; then
+  cache_download_tarball \
+    "${CACHE_FOLDER}" "ci/kokoro/install/ccache-contents" "${CACHE_NAME}" || true
+fi
+
 echo "================================================================"
-echo "Build base image with minimal development tools for ${DISTRO} $(date)."
+log_normal "Build base image with minimal development tools for ${DISTRO}."
 update_cache="false"
 
 devtools_flags=(
@@ -95,6 +111,7 @@ devtools_flags=(
   # upload it.
   "-t" "${INSTALL_IMAGE}:latest"
   "--build-arg" "NCPU=${NCPU}"
+  "--build-arg" "DISTRO=${DISTRO}"
   "-f" "ci/kokoro/install/Dockerfile.${DISTRO}"
 )
 
@@ -107,7 +124,7 @@ if [[ "${RUNNING_CI:-}" == "yes" ]] &&
   devtools_flags+=("--no-cache")
 fi
 
-echo "Running docker build with " "${devtools_flags[@]}"
+log_normal "Running docker build with " "${devtools_flags[@]}"
 if docker build "${devtools_flags[@]}" ci; then
   update_cache="true"
 fi
@@ -121,13 +138,34 @@ if "${update_cache}" && [[ "${RUNNING_CI:-}" == "yes" ]] &&
 fi
 
 echo "================================================================"
-echo "Run validation script for INSTALL instructions on ${DISTRO}."
+log_yellow "Compile and install the code and the quickstart programs."
 readonly INSTALL_RUN_IMAGE="${DOCKER_IMAGE_PREFIX}/ci-install-runtime-${DISTRO}"
 docker build -t "${INSTALL_RUN_IMAGE}" \
   "--cache-from=${INSTALL_IMAGE}:latest" \
   "--target=install" \
   "--build-arg" "NCPU=${NCPU}" \
   -f "ci/kokoro/install/Dockerfile.${DISTRO}" .
-echo "================================================================"
 
+echo "================================================================"
+log_yellow "Run quickstart programs."
 source "${PROJECT_ROOT}/ci/etc/kokoro/install/run-installed-programs.sh"
+
+echo
+log_green "Build successful."
+
+set +e
+if ! cache_upload_enabled; then
+  exit 0
+fi
+
+echo "================================================================"
+log_normal "Preparing and uploading ccache tarball."
+mkdir -p ci/kokoro/install/ccache-contents
+docker run --rm --volume "$PWD:/v" \
+  --workdir /h \
+  "${INSTALL_RUN_IMAGE}:latest" \
+  tar -zcf "/v/ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" .ccache
+cache_upload_tarball "ci/kokoro/install/ccache-contents" "${DISTRO}.tar.gz" \
+  "${CACHE_FOLDER}"
+
+exit 0


### PR DESCRIPTION
The templates now generate scripts with support
for ccache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-common/288)
<!-- Reviewable:end -->
